### PR TITLE
Add account extractor for 'Git For Windows' application

### DIFF
--- a/Windows/src/LaZagne/config/manageModules.py
+++ b/Windows/src/LaZagne/config/manageModules.py
@@ -16,6 +16,8 @@ from softwares.sysadmin.coreftp import CoreFTP
 from softwares.sysadmin.ftpnavigator import FtpNavigator
 # svn
 from softwares.svn.tortoise import Tortoise
+# git
+from softwares.git.gitforwindows import GitForWindows
 # chats
 from softwares.chats.skype import Skype
 from softwares.chats.pidgin import Pidgin
@@ -41,6 +43,7 @@ def get_categories():
 		'sysadmin': {'help': 'SCP/SSH/FTP/FTPS clients supported'},
 		'database': {'help': 'SQL clients supported'},
 		'svn': {'help': 'SVN clients supported'},
+		'git': {'help': 'GIT clients supported'},
 		'mails': {'help': 'Email clients supported'},
 		'wifi': {'help': 'Wifi'},
 		'browsers': {'help': 'Web browsers supported'},
@@ -77,6 +80,7 @@ def get_modules():
 		Turba(),
 		Wifi(), 
 		WifiPass(),
-		WinSCP()
+		WinSCP(),
+		GitForWindows()
 	]
 	return moduleNames

--- a/Windows/src/LaZagne/softwares/git/gitforwindows.py
+++ b/Windows/src/LaZagne/softwares/git/gitforwindows.py
@@ -1,0 +1,69 @@
+import os
+from config.write_output import print_output, print_debug
+from config.constant import *
+from config.header import Header
+from config.moduleInfo import ModuleInfo
+from urlparse import urlparse
+
+class GitForWindows(ModuleInfo):
+
+    def __init__(self):
+        options = {'command': '-t', 'action': 'store_true', 'dest': 'gitforwindows', 'help': 'Git for Windows'}
+        ModuleInfo.__init__(self, 'gitforwindows', 'git', options)
+
+    def extract_credentials(self, location):
+        """
+        Extract the credentials from a Git store file.
+        See "https://git-scm.com/docs/git-credential-store" for file format.
+        :param location: Full path to the Git store file
+        :return: List of credentials founds
+        """
+        pwd_found = []
+        values = {}
+        if os.path.isfile(location):
+            with open(location) as f:
+                creds = f.readlines()
+                # One line have the following format: https://user:pass@example.com
+                for cred in creds:
+                    if len(cred) > 0:
+                        parts = urlparse(cred)
+                        values["Username"] = parts.username
+                        values["Password"] = parts.password
+                        values["URL"] = parts.geturl().replace(parts.username + ":" + parts.password + "@", "").strip()
+                        pwd_found.append(values)
+
+        return pwd_found
+
+    def run(self):
+        """
+        Main function
+        """
+        # Print title
+        title = "GitForWindows"
+        Header().title_info(title)
+
+        # According to the "git-credential-store" documentation:
+        # Build a list of locations in which git credentials can be stored
+        locations = []
+        locations.append(os.environ.get("USERPROFILE") + "\\.git-credentials")
+        locations.append(os.environ.get("USERPROFILE") + "\\.config\\git\\credentials")
+        if "XDG_CONFIG_HOME" in os.environ:
+            locations.append(os.environ.get("XDG_CONFIG_HOME") + "\\git\\credentials")
+
+        # Apply the password extraction on the defined locations
+        pwd_found = []
+        for location in locations:
+            pwd_found += self.extract_credentials(location)
+
+        # Filter duplicates
+        final_pwd_found = []
+        duplicates_track = []
+        for pwd in pwd_found:
+            pwd_id = pwd["URL"] + pwd["Username"] + pwd["Password"]
+            if pwd_id not in duplicates_track:
+                final_pwd_found.append(pwd)
+                duplicates_track.append(pwd_id)
+
+        # Print the results
+        if len(final_pwd_found) > 0:
+            print_output(title, final_pwd_found)


### PR DESCRIPTION
Hello,

I have created a small module and associated category in order to extract account's credentials for the "Git For Windows" application in case in which the user use the default disk storage mode on Windows.

I have tested it with the last version of the "Git For Windows" application.

I have based my implementatin on the SVN Tortoise module in order to stick to the development standards that you have defined.

Thanks in advance :)