### PR TITLE
Add generic freedesktop protocol

### DIFF
--- a/Linux/lazagne/config/manageModules.py
+++ b/Linux/lazagne/config/manageModules.py
@@ -1,6 +1,7 @@
 # keyring
 from lazagne.softwares.wallet.gnome import Gnome
 from lazagne.softwares.wallet.kde import kde
+from lazagne.softwares.wallet.libsecret import libsecret
 # browsers
 from lazagne.softwares.browsers.mozilla import Mozilla
 from lazagne.softwares.browsers.opera import Opera
@@ -32,7 +33,7 @@ def get_categories():
 		'wallet': {'help': 'Windows credentials (credential manager, etc.)'}
 	}
 	return category
-	
+
 def get_modules():
 	moduleNames = [
 		ClawsMail(),
@@ -49,6 +50,7 @@ def get_modules():
 		Squirrel(),
 		Wifi(),
 		Wpa_supplicant(),
-		kde()
+		kde(),
+		libsecret()
 	]
 	return moduleNames

--- a/Linux/lazagne/softwares/wallet/libsecret.py
+++ b/Linux/lazagne/softwares/wallet/libsecret.py
@@ -1,0 +1,30 @@
+import os, sys
+
+from lazagne.config.write_output import print_debug
+from lazagne.config.moduleInfo import ModuleInfo
+
+class libsecret(ModuleInfo):
+    def __init__(self):
+        options = {'command': '-k', 'action': 'store_true', 'dest': 'kwallet', 'help': 'KWallet'}
+        ModuleInfo.__init__(self, 'libsecret', 'wallet', options)
+
+    def run(self, software_name = None):
+        items = []
+        try:
+            import secretstorage
+            import dbus
+            import datetime
+            for item in secretstorage.Collection(dbus.SessionBus()).get_all_items():
+                values = {
+                    'created': datetime.datetime.fromtimestamp(item.get_created()),
+                    'modified': datetime.datetime.fromtimestamp(item.get_modified()),
+                    'content-type': item.get_secret_content_type(),
+                    'label': item.get_label(),
+                    'Password': item.get_secret(),
+                }
+                for k, v in item.get_attributes().iteritems():
+                    values[str(k)] = str(v)
+                items.append(values)
+            return items
+        except Exception as e:
+            print_debug('ERROR', 'libsecret: {0}'.format(e))


### PR DESCRIPTION
I'm preparing to include lazagne for Linux to pupy. There is limited environment, so some more generic approaches should be used for wallets.