### PR TITLE
from colorama import Fore, Style

### DIFF
--- a/Linux/lazagne/config/write_output.py
+++ b/Linux/lazagne/config/write_output.py
@@ -8,6 +8,7 @@ from lazagne.config.color import bcolors
 from lazagne.config.constant import constant
 import logging
 import json
+from colorama import Fore, Style
 
 # --------------------------- Functions used to write ---------------------------
 


### PR DESCRIPTION
Should fix 8 issues in #135

https://github.com/AlessandroZ/LaZagne/blob/master/CHANGELOG#L3 says that we got rid of [colorama](https://github.com/tartley/colorama) but `Fore` and `Style` are not defined in this repo.