### PR TITLE
Issues with directory initialization for Cyberduck and FileZilla modules

### DIFF
--- a/Windows/lazagne/softwares/sysadmin/cyberduck.py
+++ b/Windows/lazagne/softwares/sysadmin/cyberduck.py
@@ -13,7 +13,7 @@ class Cyberduck(ModuleInfo):
 
 	# find the user.config file containing passwords
 	def get_application_path(self):
-		directory = os.path.join(constant.profile['APPDATA'], u'\Cyberduck')
+		directory = os.path.join(constant.profile['APPDATA'], u'Cyberduck')
 		if os.path.exists(directory):
 			for dr in os.listdir(directory):
 				if dr.startswith(u'Cyberduck'):

--- a/Windows/lazagne/softwares/sysadmin/filezilla.py
+++ b/Windows/lazagne/softwares/sysadmin/filezilla.py
@@ -11,7 +11,7 @@ class Filezilla(ModuleInfo):
 		ModuleInfo.__init__(self, 'filezilla', 'sysadmin', options, need_to_be_in_env=False)
 
 	def run(self, software_name = None):		
-		directory = os.path.join(constant.profile['APPDATA'], u'\FileZilla')
+		directory = os.path.join(constant.profile['APPDATA'], u'FileZilla')
 		
 		interesting_xml_file = []
 		info_xml_file = []


### PR DESCRIPTION
In both cases the "directory" var is wrongly initialized due to the leading single backslash in the string appended when calling os.path.join(). It initializes to 'C:\FileZilla' and 'C:\Cyberduck' instead of the correct values.
This causes LaZagne to not find the necessary files and therefore stating that that cyberduck and filezilla are not installed.

edit: from the [python doc on os.path.join](https://docs.python.org/2/library/os.path.html#os.path.join): "_If a component is an absolute path, all previous components are thrown away and joining continues from the absolute path component._"