### PR TITLE
See traceback (creddump7->object.py)

### DIFF
--- a/Windows/lazagne/softwares/windows/creddump7/object.py
+++ b/Windows/lazagne/softwares/windows/creddump7/object.py
@@ -69,7 +69,11 @@ def read_value(addr_space, value_type, vaddr):
     buf = addr_space.read(vaddr, type_size)
     if buf is None:
         return None
-    (val,) = struct.unpack(type_unpack_char, buf)
+
+    try:
+        (val,) = struct.unpack(type_unpack_char, buf)
+    except:
+        return None
 
     return val
 


### PR DESCRIPTION
```
  File "lazagne\softwares\windows\creddump7\newobj.py", line 210, in __init__
  File "lazagne\softwares\windows\creddump7\object.py", line 70, in read_value
error: unpack requires a string argument of length 4
```