### PR TITLE
See traceback (lsasecrets)

### DIFF
--- a/Windows/lazagne/softwares/windows/creddump7/win32/lsasecrets.py
+++ b/Windows/lazagne/softwares/windows/creddump7/win32/lsasecrets.py
@@ -78,9 +78,12 @@ def decrypt_secret(secret, key):
         enc_block = secret[i:i+8]
         block_key = key[j:j+7]
         des_key = str_to_key(block_key)
-
         crypter = des(des_key, ECB)
-        decrypted_data += crypter.decrypt(enc_block)
+
+        try:
+            decrypted_data += crypter.decrypt(enc_block)
+        except:
+            continue
 
         j += 7
         if len(key[j:j+7]) < 7:


### PR DESCRIPTION
```
   File "lazagne\softwares\windows\creddump7\win32\lsasecrets.py", line 127, in get_secret_by_name
   File "lazagne\softwares\windows\creddump7\win32\lsasecrets.py", line 78, in decrypt_secret
   File "Crypto\Cipher\blockalgo.py", line 295, in decrypt
 ValueError: Input strings must be a multiple of 8 in length
```