### PR TITLE
See traceback (bug in lsa secrets if no reg hives)

### DIFF
--- a/Windows/lazagne/softwares/windows/creddump7/win32/lsasecrets.py
+++ b/Windows/lazagne/softwares/windows/creddump7/win32/lsasecrets.py
@@ -19,7 +19,7 @@
 @contact:      bdolangavitt@wesleyan.edu
 """
 
-import hashlib
+import hashlib, os
 
 from .rawreg import *
 from ..addrspace import HiveFileAddressSpace
@@ -176,6 +176,9 @@ def get_secrets(sysaddr, secaddr, vista):
 
 
 def get_file_secrets(sysfile, secfile, vista):
+    if not os.path.isfile(sysfile) or not os.path.isfile(secfile):
+        return
+        
     sysaddr = HiveFileAddressSpace(sysfile)
     secaddr = HiveFileAddressSpace(secfile)
 


### PR DESCRIPTION
```
  File "lazagne\softwares\windows\lsa_secrets.py", line 25, in run
  File "lazagne\softwares\windows\creddump7\win32\lsasecrets.py", line 177, in get_file_secrets
  File "lazagne\softwares\windows\creddump7\addrspace.py", line 79, in __init__
  File "lazagne\softwares\windows\creddump7\addrspace.py", line 40, in __init__
IOError: [Errno 2] No such file or directory: 'c:\\docume~1\\admini~1\\locals~1\\temp\\asczhxaqk'
```