### PR TITLE
Filter fully empty credentials

### DIFF
--- a/Windows/lazagne/softwares/browsers/chromium_based.py
+++ b/Windows/lazagne/softwares/browsers/chromium_based.py
@@ -72,6 +72,9 @@ class ChromiumBased(ModuleInfo):
             try:
                 # Decrypt the Password
                 password = Win32CryptUnprotectData(password, is_current_user=constant.is_current_user, user_dpapi=constant.user_dpapi)
+                if not url and not login and not password:
+                    continue
+                    
                 credentials.append((url, login, password))
             except Exception:
                 self.debug(traceback.format_exc())


### PR DESCRIPTION
Sometime I got {'URL': '', 'Login': '', 'Password': ''} from Chrome module.
When at least one field is not empty this information can ca applied but otherwise it's a rubbish, so we can skip it.