### PR TITLE
Windows getting user name method change

### DIFF
--- a/Windows/lazagne/config/run.py
+++ b/Windows/lazagne/config/run.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
 # !/usr/bin/python
 import ctypes
-import getpass
 import logging
 import sys
 import traceback
 
 from lazagne.config.change_privileges import list_sids, rev2self, impersonate_sid_long_handle
-from lazagne.config.users import get_user_list_on_filesystem, set_env_variables
+from lazagne.config.users import get_user_list_on_filesystem, set_env_variables, get_username_winapi
 from lazagne.config.dpapi_structure import SystemDpapi, are_masterkeys_retrieved
 from lazagne.config.execute_cmd import save_hives, delete_hives
 from lazagne.config.write_output import print_debug, StandardOutput
@@ -187,7 +186,7 @@ def run_lazagne(category_selected='all', subcategories={}, password=None):
 
     constant.is_current_user = True
     # constant.username = getpass.getuser().decode(sys.getfilesystemencoding())
-    constant.username = getpass.getuser()
+    constant.username = get_username_winapi()
     if not constant.username.endswith('$'):
         
         constant.finalResults = {'User': constant.username}

--- a/Windows/lazagne/config/users.py
+++ b/Windows/lazagne/config/users.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # !/usr/bin/python
 import os
+import ctypes
 
 from lazagne.config.winstructure import get_os_version
 from lazagne.config.constant import constant
@@ -55,3 +56,23 @@ def set_env_variables(user, to_impersonate=False):
     # Replace "drive" and "user" with the correct values
     for env in constant.profile:
         constant.profile[env] = constant.profile[env].format(drive=constant.drive, user=user)
+
+
+def get_username_winapi():
+    GetUserNameW = ctypes.windll.advapi32.GetUserNameW
+    GetUserNameW.argtypes = [ctypes.c_wchar_p, ctypes.POINTER(ctypes.c_uint)]
+    GetUserNameW.restype = ctypes.c_uint
+
+    _buffer = ctypes.create_unicode_buffer(1)
+    size = ctypes.c_uint(len(_buffer))
+    while not GetUserNameW(_buffer, ctypes.byref(size)):
+        # WinError.h
+        # define ERROR_INSUFFICIENT_BUFFER        122L    // dderror
+        if ctypes.GetLastError() == 122:
+            _buffer = ctypes.create_unicode_buffer(len(_buffer)*2)
+            size.value = len(_buffer)
+        
+        else:
+            return # Unusual error
+
+    return _buffer.value


### PR DESCRIPTION
Hello. Due to:
```
  File "\lazagne\config\run.py", line 190, in run_lazagne
  File "\getpass.py", line 157, in getuser
ImportError: No module named pwd
```
This exception happens in XP/2003.
