### PR TITLE
decrypt_with_key (see traceback)

### DIFF
--- a/Windows/lazagne/config/DPAPI/masterkey.py
+++ b/Windows/lazagne/config/DPAPI/masterkey.py
@@ -75,7 +75,7 @@ class MasterKey(DataStruct):
         This function also extracts the HMAC part of the decrypted stuff and compare it with the computed one.
         Note that, once successfully decrypted, the masterkey will not be decrypted anymore; this function will simply return.
         """
-        if self.decrypted:
+        if self.decrypted or not pwdhash:
             return
 
         # Compute encryption key


### PR DESCRIPTION
```
  File "libs\lazagne\config\dpapi_structure.py", line 164, in __init__
  File "libs\lazagne\config\DPAPI\masterkey.py", line 432, in try_system_credential
  File "libs\lazagne\config\DPAPI\masterkey.py", line 83, in decrypt_with_key
  File "libs\lazagne\config\DPAPI\crypto.py", line 333, in dataDecrypt
  File "libs\lazagne\config\DPAPI\crypto.py", line 313, in pbkdf2
  File "libs\hmac.py", line 136, in new
  File "libs\hmac.py", line 71, in __init__
TypeError: object of type 'NoneType' has no len()
```
Sometimes unchecked parameter "pwdhash" goes to "hmac.new(passphrase" as None ans causes this exception.