### PR TITLE
Change Win32CryptUnprotectData return value

### DIFF
--- a/Windows/lazagne/config/winstructure.py
+++ b/Windows/lazagne/config/winstructure.py
@@ -536,14 +536,10 @@ def Win32CryptUnprotectData(cipherText, entropy=False, is_current_user=True, use
 
             if CryptUnprotectData(byref(blobIn), None, byref(blobEntropy), None, None, 0, byref(blobOut)):
                 return getData(blobOut).decode("utf-8")
-            else:
-                return False
 
         else:
             if CryptUnprotectData(byref(blobIn), None, None, None, None, 0, byref(blobOut)):
                 return getData(blobOut).decode("utf-8")
-            else:
-                return False
 
     elif user_dpapi and user_dpapi.unlocked:
         # entropy should be an hex value


### PR DESCRIPTION
I think it's bad to return False if failed because it's not a boolean function, it should return None (empty return) if fails. Also casting False to str will cause smth like this:

>  'URL': 'http://192.168.0.1', 'Login': 'admin', 'Password': False