### PR TITLE
Path resolution problem bugfix

### DIFF
--- a/Windows/lazagne/softwares/sysadmin/opensshforwindows.py
+++ b/Windows/lazagne/softwares/sysadmin/opensshforwindows.py
@@ -10,7 +10,7 @@ class OpenSSHForWindows(ModuleInfo):
 
     def __init__(self):
         ModuleInfo.__init__(self, 'opensshforwindows', 'sysadmin')
-        self.key_files_location = os.path.join(constant.profile["USERPROFILE"], u'.ssh')
+        #self.key_files_location = os.path.join(constant.profile["USERPROFILE"], u'.ssh')
 
     # Retrieve SSH private key even if a passphrase is set (the goal is to remove crypto dependency)
     # def is_private_key_unprotected(self, key_content_encoded, key_algorithm):
@@ -77,7 +77,7 @@ class OpenSSHForWindows(ModuleInfo):
         """
         Main function
         """
-
+        self.key_files_location = os.path.join(constant.profile["USERPROFILE"], u'.ssh')
         # Extract all DSA/RSA private keys that are not protected with a passphrase
         unprotected_private_keys = self.extract_private_keys_unprotected()
 


### PR DESCRIPTION
During my tests I figured that the module is failing. I had ssh files without password in my user dir (under .ssh) but they would not be detected. My testing revealed that the Userprofile path resolution is failing. I was debugging the value of  "self.key_files_location" which gets resolved to -> "{drive}:\Users{user}.ssh"

Apparently some namespace issue. I fixed the bug by defining the path in the "run" method. Not the ideal solution but worked for me.