### PR TITLE
Enhancement for SSH key harvesting

### DIFF
--- a/Windows/lazagne/softwares/sysadmin/opensshforwindows.py
+++ b/Windows/lazagne/softwares/sysadmin/opensshforwindows.py
@@ -58,7 +58,7 @@ class OpenSSHForWindows(ModuleInfo):
                             # Determine the type of the key (public/private) and what is it algorithm
                             if "DSA PRIVATE KEY" in key_content_encoded:
                                 key_algorithm = "DSA"
-                            elif "RSA PRIVATE KEY" in key_content_encoded:
+                            elif "RSA PRIVATE KEY" in key_content_encoded or "OPENSSH PRIVATE KEY" in key_content_encoded:
                                 key_algorithm = "RSA"
                             else:
                                 key_algorithm = None


### PR DESCRIPTION
Since 2014 there is a new standard used by ssh-keygen which creates openssh keys with "OPENSSH PRIVATE KEY" header. This standard, however, does not make it easy to understand if the key has a passphrase or not (as compared to the old RSA standard which specifies "ENCRYPTED" label for an RSA key having a passphrase). Anyway, my fix could still allow to recover some new standard keys which have no passphrase. I stumbled upon this while creating a new key pair and placing it (private key) into the .ssh folder for my Windows git client.