### PR TITLE
Python3 fixes

### DIFF
--- a/Linux/lazagne/softwares/browsers/mozilla.py
+++ b/Linux/lazagne/softwares/browsers/mozilla.py
@@ -486,8 +486,8 @@ class Mozilla(ModuleInfo):
                         pwd_found.append(
                             {
                                 'URL': url,
-                                'Login': self.decrypt(key=key, iv=user[1], ciphertext=user[2]),
-                                'Password': self.decrypt(key=key, iv=password[1], ciphertext=password[2]),
+                                'Login': self.decrypt(key=key, iv=user[1], ciphertext=user[2]).decode('utf8'),
+                                'Password': self.decrypt(key=key, iv=password[1], ciphertext=password[2]).decode('utf8'),
                             }
                         )
                     except Exception:

--- a/Linux/lazagne/softwares/wallet/libsecret.py
+++ b/Linux/lazagne/softwares/wallet/libsecret.py
@@ -83,7 +83,7 @@ class Libsecret(ModuleInfo):
                         'modified': str(datetime.datetime.fromtimestamp(item.get_modified())),
                         'content-type': item.get_secret_content_type(),
                         'label': item.get_label(),
-                        'Password': item.get_secret(),
+                        'Password': item.get_secret().decode('utf8'),
                         'collection': label,
                     }
 


### PR DESCRIPTION
Some of the username/password outputs on python3 were showing up as:

```
Login: b'username@website.com'
Password: b'mySuperStrongPa$$word'
```
I've appended `.decode('utf8')` to those lines, which fixes the issue, and works on both python2 & 3.

It's possible that there are more modules which have this issue, but of those that I have on my system, these are the only ones that had this issue.