### PR TITLE
Travis CI: Do not hard-code Trusty, it EOLs next month

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
-sudo: required
 language: python
 os:
 - linux
-dist: trusty
 python:
 - '2.7'
 before_install:


### PR DESCRIPTION
Do not hard-code __Trusty__ because it reaches its end-of-life next month.
https://wiki.ubuntu.com/Releases

Also, [Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).