### PR TITLE
Typo: str is os.environ --> str in os.environ

### DIFF
--- a/Linux/lazagne/config/homes.py
+++ b/Linux/lazagne/config/homes.py
@@ -114,7 +114,7 @@ def sessions(setenv=True):
                         except Exception:
                             continue
 
-                    if 'DBUS_SESSION_BUS_ADDRESS' is os.environ:
+                    if 'DBUS_SESSION_BUS_ADDRESS' in os.environ:
                         previous = os.environ['DBUS_SESSION_BUS_ADDRESS']
 
                     os.environ['DBUS_SESSION_BUS_ADDRESS'] = address


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/AlessandroZ/LaZagne

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./Linux/lazagne/config/homes.py:117:24: F632 use ==/!= to compare str, bytes, and int literals
                    if 'DBUS_SESSION_BUS_ADDRESS' is os.environ:
                       ^
1     F632 use ==/!= to compare str, bytes, and int literals
1
```