### PR TITLE
Need 'self' to get to ModuleInfo.error() on line 116

### DIFF
--- a/Mac/lazagne/softwares/browsers/mozilla.py
+++ b/Mac/lazagne/softwares/browsers/mozilla.py
@@ -88,8 +88,7 @@ class Mozilla(ModuleInfo):
         self.path = os.path.expanduser(path)
         ModuleInfo.__init__(self, browser_name, category='browsers')
 
-    @staticmethod
-    def get_firefox_profiles(directory):
+    def get_firefox_profiles(self, directory):
         """
         List all profiles
         """


### PR DESCRIPTION
https://github.com/AlessandroZ/LaZagne/blob/master/Mac/lazagne/config/module_info.py#L32
```
./Mac/lazagne/softwares/browsers/mozilla.py:117:13: F821 undefined name 'self'
            self.error(u'An error occurred while reading profiles.ini: {}'.format(e))
            ^
```