### PR TITLE
General exceptions --> specific exceptions

### DIFF
--- a/Mac/lazagne/softwares/browsers/mozilla.py
+++ b/Mac/lazagne/softwares/browsers/mozilla.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*- 
+# -*- coding: utf-8 -*-
 # portable decryption functions and BSD DB parsing by Laurent Clevy (@lorenzo2472)
 # from https://github.com/lclevy/firepwd/blob/master/firepwd.py
 
@@ -38,13 +38,13 @@ def convert_to_byte(s):
 
 
 def l(n):
-    if python_version == 2:
+    try:
         return long(n)
-    else:
+    except NameError:
         return int(n)
 
 
-def o(c): 
+def o(c):
     if python_version == 2:
         return ord(c)
     else:
@@ -108,7 +108,7 @@ class Mozilla(ModuleInfo):
 
                     else: # No "IsRelative" in profiles.ini
                         profile_path = os.path.join(directory, cp.get(section, 'Path').strip())
-                    
+
                     if profile_path:
                         profile_list.append(profile_path)
 
@@ -124,9 +124,9 @@ class Mozilla(ModuleInfo):
         try:
             row = None
             # Remove error when file is empty
-            with open(os.path.join(profile, 'key4.db'), 'rb') as f: 
+            with open(os.path.join(profile, 'key4.db'), 'rb') as f:
                 content = f.read()
-            
+
             if content:
                 conn = sqlite3.connect(os.path.join(profile, 'key4.db'))  # Firefox 58.0.2 / NSS 3.35 with key4.db in SQLite
                 c = conn.cursor()

--- a/Windows/lazagne/config/DPAPI/crypto.py
+++ b/Windows/lazagne/config/DPAPI/crypto.py
@@ -29,7 +29,7 @@ from lazagne.config.winstructure import char_to_int
 
 try:
     xrange
-except Exception:
+except NameError:
     xrange = range
 
 AES_BLOCK_SIZE = 16

--- a/Windows/lazagne/config/crypto/pyaes/aes.py
+++ b/Windows/lazagne/config/crypto/pyaes/aes.py
@@ -74,7 +74,7 @@ def _concat_list(a, b):
 # Python 3 compatibility
 try:
     xrange
-except Exception:
+except NameError:
     xrange = range
 
     # Python 3 supports bytes, which is already an array of integers

--- a/Windows/lazagne/config/crypto/pyaes/util.py
+++ b/Windows/lazagne/config/crypto/pyaes/util.py
@@ -34,7 +34,7 @@ def _get_byte(c):
 
 try:
     xrange
-except Exception:
+except NameError:
 
     def to_bufferable(binary):
         if isinstance(binary, bytes):

--- a/Windows/lazagne/softwares/browsers/mozilla.py
+++ b/Windows/lazagne/softwares/browsers/mozilla.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*- 
+# -*- coding: utf-8 -*-
 # portable decryption functions and BSD DB parsing by Laurent Clevy (@lorenzo2472)
 # from https://github.com/lclevy/firepwd/blob/master/firepwd.py
 
@@ -18,7 +18,7 @@ from lazagne.config.constant import constant
 from lazagne.config.crypto.pyDes import triple_des, CBC
 from lazagne.config.dico import get_dic
 from lazagne.config.module_info import ModuleInfo
-from lazagne.config.winstructure import char_to_int, convert_to_byte, python_version
+from lazagne.config.winstructure import char_to_int, convert_to_byte
 
 try:
     from ConfigParser import RawConfigParser  # Python 2.7
@@ -28,9 +28,9 @@ import os
 
 
 def l(n):
-    if python_version == 2:
+    try:
         return long(n)
-    else:
+    except NameError:
         return int(n)
 
 
@@ -91,7 +91,7 @@ class Mozilla(ModuleInfo):
 
                     else: # No "IsRelative" in profiles.ini
                         profile_path = os.path.join(directory, cp.get(section, 'Path').strip())
-                    
+
                     if profile_path:
                         profile_list.append(profile_path)
 
@@ -107,9 +107,9 @@ class Mozilla(ModuleInfo):
         try:
             row = None
             # Remove error when file is empty
-            with open(os.path.join(profile, 'key4.db'), 'rb') as f: 
+            with open(os.path.join(profile, 'key4.db'), 'rb') as f:
                 content = f.read()
-            
+
             if content:
                 conn = sqlite3.connect(os.path.join(profile, 'key4.db'))  # Firefox 58.0.2 / NSS 3.35 with key4.db in SQLite
                 c = conn.cursor()

--- a/Windows/lazagne/softwares/memory/libkeepass/pureSalsa20.py
+++ b/Windows/lazagne/softwares/memory/libkeepass/pureSalsa20.py
@@ -176,8 +176,10 @@ little2_i32 = Struct("<2i")  # 2 little-endian 32-bit signed ints.
 _version = 'p3.2'
 
 try:
+    long
     xrange
-except Exception:
+except NameError:
+    long = int
     xrange = range
 
 


### PR DESCRIPTION
These relatively minor changes follow the Python porting best practice [___use feature detection instead of version detection___](https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection).  They make it easier to lint the code to spot Python 3 incompatibilities and in the case of __pureSalsa20.py__ define __long__ for compatibility with both Python 2 and Python 3.