### PR TITLE
Travis CI: Add linting runs in Python 2 and Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
       dist: xenial  # required for Python >= 3.7
       <<: *lint_steps
     - name: "Test and deploy on Python 2.7"
-      python:'2.7'
+      python: '2.7'
 
 before_install:
 - pip install --upgrade pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,3 +34,23 @@ deploy:
     tags: true
     all_branches: true
     repo: AlessandroZ/LaZagne
+
+lint_steps: &lint_steps
+  before_install:
+    - pip install --upgrade pip
+    - pip install flake8
+  script: flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
+  before_deploy: true  # override
+  deploy: true  # override
+
+matrix:
+  include:
+    - name: "Lint on Python 2.7"
+      python: '2.7'
+      <<: *lint_steps
+    - name: "Lint on Python 3.7"
+      python: '3.7'
+      dist: xenial  # required for Python >= 3.7
+      <<: *lint_steps
+   allow_failures:
+    - python: '3.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
       python: '3.7'
       dist: xenial  # required for Python >= 3.7
       <<: *lint_steps
-    - name "Test and deploy on Python 2.7"
+    - name: "Test and deploy on Python 2.7"
       python:'2.7'
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,27 @@
 language: python
 os:
 - linux
+
+lint_steps: &lint_steps
+  before_install:
+    - pip install --upgrade pip
+    - pip install flake8
+  script: flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
+  before_deploy: true  # override
+  deploy: true  # override
+
+matrix:
+  include:
+    - name: "Lint on Python 2.7"
+      python: '2.7'
+      <<: *lint_steps
+    - name: "Lint on Python 3.7"
+      python: '3.7'
+      dist: xenial  # required for Python >= 3.7
+      <<: *lint_steps
+  allow_failures:
+    - python: '3.7'
+
 python:
 - '2.7'
 before_install:
@@ -34,23 +55,3 @@ deploy:
     tags: true
     all_branches: true
     repo: AlessandroZ/LaZagne
-
-lint_steps: &lint_steps
-  before_install:
-    - pip install --upgrade pip
-    - pip install flake8
-  script: flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
-  before_deploy: true  # override
-  deploy: true  # override
-
-matrix:
-  include:
-    - name: "Lint on Python 2.7"
-      python: '2.7'
-      <<: *lint_steps
-    - name: "Lint on Python 3.7"
-      python: '3.7'
-      dist: xenial  # required for Python >= 3.7
-      <<: *lint_steps
-  allow_failures:
-    - python: '3.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
   allow_failures:
     - python: '3.7'
   include:
+    - name: "Test and deploy on Python 2.7"
+      python: '2.7'
     - name: "Lint on Python 2.7"
       python: '2.7'
       <<: *lint_steps
@@ -21,8 +23,6 @@ matrix:
       python: '3.7'
       dist: xenial  # required for Python >= 3.7
       <<: *lint_steps
-    - name: "Test and deploy on Python 2.7"
-      python: '2.7'
 
 before_install:
 - pip install --upgrade pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,5 +52,5 @@ matrix:
       python: '3.7'
       dist: xenial  # required for Python >= 3.7
       <<: *lint_steps
-   allow_failures:
+  allow_failures:
     - python: '3.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ lint_steps: &lint_steps
   deploy: true  # override
 
 matrix:
+  allow_failures:
+    - python: '3.7'
   include:
     - name: "Lint on Python 2.7"
       python: '2.7'
@@ -19,11 +21,9 @@ matrix:
       python: '3.7'
       dist: xenial  # required for Python >= 3.7
       <<: *lint_steps
-  allow_failures:
-    - python: '3.7'
+    - name "Test and deploy on Python 2.7"
+      python:'2.7'
 
-python:
-- '2.7'
 before_install:
 - pip install --upgrade pip
 - sudo add-apt-repository ppa:ubuntu-wine/ppa -y


### PR DESCRIPTION
The Python 3 run is in __allow_failures__ mode until the port to Python 3 is complete.