### PR TITLE
Create a single requirements.txt for all platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ before_install:
 - wine c:\\Python27\\python.exe -m pip install pywin32-224-cp27-none-win_amd64.whl
 - wine c:\\Python27\\python.exe -m pip install pyinstaller -r requirements.txt
 - wine c:\\Python27\\Scripts\\pyinstaller --noconsole --onefile Windows/lazagne.spec
-- sleep 1  # Give PyInstaller a second to finish writing to stdout
 script:
+- sleep 1  # Give PyInstaller a second to finish writing to stdout
 - wine Z:\\home\\travis\\build\\AlessandroZ\\LaZagne\\dist\\laZagne.exe all
 before_deploy:
 - tar -zcvf lazagne.tar.gz dist/lazagne.exe

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ before_install:
 - wine c:\\Python27\\python.exe -m pip install pywin32-224-cp27-none-win_amd64.whl
 - wine c:\\Python27\\python.exe -m pip install pyinstaller -r requirements.txt
 - wine c:\\Python27\\Scripts\\pyinstaller --noconsole --onefile Windows/lazagne.spec
+- sleep 1  # Give PyInstaller a second to finish writing to stdout
 script:
 - wine Z:\\home\\travis\\build\\AlessandroZ\\LaZagne\\dist\\laZagne.exe all
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,11 +31,7 @@ before_install:
 - wine msiexec /i python.msi /qn
 - wget https://files.pythonhosted.org/packages/83/cc/2e39fa39b804f7b6e768a37657d75eb14cd917d1f43f376dad9f7c366ccf/pywin32-224-cp27-cp27m-win_amd64.whl --output-document=pywin32-224-cp27-none-win_amd64.whl
 - wine c:\\Python27\\python.exe -m pip install pywin32-224-cp27-none-win_amd64.whl
-- wine c:\\Python27\\python.exe -m pip install pyasn1
-- wine c:\\Python27\\python.exe -m pip install enum34
-- wine c:\\Python27\\python.exe -m pip install rsa
-- wine c:\\Python27\\python.exe -m pip install https://github.com/AlessandroZ/pypykatz/archive/master.zip
-- wine c:\\Python27\\python.exe -m pip install pyinstaller
+- wine c:\\Python27\\python.exe -m pip install pyinstaller -r requirements.txt
 - wine c:\\Python27\\Scripts\\pyinstaller --noconsole --onefile Windows/lazagne.spec
 script:
 - wine Z:\\home\\travis\\build\\AlessandroZ\\LaZagne\\dist\\laZagne.exe all

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,11 @@ matrix:
       <<: *lint_steps
 
 before_install:
-- pip install --upgrade pip
 - sudo add-apt-repository ppa:ubuntu-wine/ppa -y
 - sudo apt-get update -qq
 - sudo apt-get install -qq wine
-- wget https://www.python.org/ftp/python/2.7.9/python-2.7.9.amd64.msi --output-document=python.msi
+- wget https://www.python.org/ftp/python/2.7.16/python-2.7.16.amd64.msi --output-document=python.msi
 - wine msiexec /i python.msi /qn
-- wine c:\\Python27\\python.exe -m pip install --upgrade pip
 - wget https://files.pythonhosted.org/packages/83/cc/2e39fa39b804f7b6e768a37657d75eb14cd917d1f43f376dad9f7c366ccf/pywin32-224-cp27-cp27m-win_amd64.whl --output-document=pywin32-224-cp27-none-win_amd64.whl
 - wine c:\\Python27\\python.exe -m pip install pywin32-224-cp27-none-win_amd64.whl
 - wine c:\\Python27\\python.exe -m pip install pyinstaller -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ before_install:
 - sudo apt-get install -qq wine
 - wget https://www.python.org/ftp/python/2.7.9/python-2.7.9.amd64.msi --output-document=python.msi
 - wine msiexec /i python.msi /qn
+- wine c:\\Python27\\python.exe -m pip install --upgrade pip
 - wget https://files.pythonhosted.org/packages/83/cc/2e39fa39b804f7b6e768a37657d75eb14cd917d1f43f376dad9f7c366ccf/pywin32-224-cp27-cp27m-win_amd64.whl --output-document=pywin32-224-cp27-none-win_amd64.whl
 - wine c:\\Python27\\python.exe -m pip install pywin32-224-cp27-none-win_amd64.whl
 - wine c:\\Python27\\python.exe -m pip install pyinstaller -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+enum34; sys.platform == "win32" and python_version < "3.4"
+psutil; sys.platform != "darwin" and sys.platform != "win32"
+pyasn1
+rsa; sys.platform == "win32"
+secretstorage; sys.platform != "darwin" and sys.platform != "win32"
+https://github.com/AlessandroZ/pypykatz/archive/master.zip # should point to pypykatz if my PR is approved; sys.platform == "win32"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-enum34; python_version < '3.4'  # and sys_platform == 'win32'
 psutil; sys_platform not in ('darwin', 'win32')
 pyasn1
 rsa; sys_platform == 'win32'
 secretstorage; sys_platform not in ('darwin', 'win32')
 https://github.com/AlessandroZ/pypykatz/archive/master.zip; sys_platform == 'win32'  # should point to pypykatz if my PR is approved
+enum34; python_version < '3.4'  # and sys_platform == 'win32'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-psutil; sys_platform not in ('darwin', 'win32')
+enum34; python_version < '3.4' and sys_platform == 'win32'
+psutil; sys_platform == 'linux' or sys_platform == 'linux2'
 pyasn1
 rsa; sys_platform == 'win32'
-secretstorage; sys_platform not in ('darwin', 'win32')
+secretstorage; sys_platform == 'linux' or sys_platform == 'linux2'
 https://github.com/AlessandroZ/pypykatz/archive/master.zip; sys_platform == 'win32'  # should point to pypykatz if my PR is approved
-enum34; python_version < '3.4'  # and sys_platform == 'win32'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-enum34; sys.platform == "win32" and python_version < "3.4"
-psutil; sys.platform != "darwin" and sys.platform != "win32"
+enum34; python_version < '3.4' and sys_platform == 'win32'
+psutil; sys_platform not in ('darwin', 'win32')
 pyasn1
-rsa; sys.platform == "win32"
-secretstorage; sys.platform != "darwin" and sys.platform != "win32"
-https://github.com/AlessandroZ/pypykatz/archive/master.zip # should point to pypykatz if my PR is approved; sys.platform == "win32"
+rsa; sys_platform == 'win32'
+secretstorage; sys_platform not in ('darwin', 'win32')
+https://github.com/AlessandroZ/pypykatz/archive/master.zip; sys_platform == 'win32'  # should point to pypykatz if my PR is approved

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-enum34; python_version < '3.4' and sys_platform == 'win32'
+enum34; python_version < '3.4'  # and sys_platform == 'win32'
 psutil; sys_platform not in ('darwin', 'win32')
 pyasn1
 rsa; sys_platform == 'win32'


### PR DESCRIPTION
Create a requirements.txt that uses https://www.python.org/dev/peps/pep-0508 in conditionally install on Linux, Mac, Windows.  Upgrade the wine Python from 2.7.9 to 2.7.16 to ensure we have a pip that understands PEP508.