### PR TITLE
Finish the migration to the new requirements.txt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
+os: linux
 language: python
-os:
-- linux
 
 lint_steps: &lint_steps
   before_install:
@@ -20,10 +19,8 @@ matrix:
       before_install:
       - python -m pip install --upgrade pip
       - pip install pyinstaller -r requirements.txt
-      #- pip install enum34 pyasn1 pyinstaller rsa https://github.com/AlessandroZ/pypykatz/archive/master.zip
       script:
        - pyinstaller --onefile Mac/laZagne.py
-       - sw_vers  # Mac OS X 10.13.3
        - ls -l dist  # See file size (4.8 mb), etc.
        - dist/laZagne all
     - name: "Lint on Python 2.7"
@@ -40,13 +37,12 @@ before_install:
 - sudo apt-get install -qq wine
 - wget https://www.python.org/ftp/python/2.7.16/python-2.7.16.amd64.msi --output-document=python.msi
 - wine msiexec /i python.msi /qn
-- wget https://files.pythonhosted.org/packages/83/cc/2e39fa39b804f7b6e768a37657d75eb14cd917d1f43f376dad9f7c366ccf/pywin32-224-cp27-cp27m-win_amd64.whl --output-document=pywin32-224-cp27-none-win_amd64.whl
-- wine c:\\Python27\\python.exe -m pip install pywin32-224-cp27-none-win_amd64.whl
 - wine c:\\Python27\\python.exe -m pip install pyinstaller -r requirements.txt
 - wine c:\\Python27\\Scripts\\pyinstaller --noconsole --onefile Windows/lazagne.spec
+- sleep 2  # Give PyInstaller two seconds to finish writing to stdout
+- ls -l dist  # See file size (4.8 mb), etc.
 install: true  # do not repeat `pip install -r requirements.txt`
 script:
-- sleep 1  # Give PyInstaller a second to finish writing to stdout
 - wine Z:\\home\\travis\\build\\AlessandroZ\\LaZagne\\dist\\laZagne.exe all
 before_deploy:
 - tar -zcvf lazagne.tar.gz dist/lazagne.exe

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,10 @@ before_install:
 - sudo apt-get install -qq wine
 - wget https://www.python.org/ftp/python/2.7.16/python-2.7.16.amd64.msi --output-document=python.msi
 - wine msiexec /i python.msi /qn
+- wget https://files.pythonhosted.org/packages/83/cc/2e39fa39b804f7b6e768a37657d75eb14cd917d1f43f376dad9f7c366ccf/pywin32-224-cp27-cp27m-win_amd64.whl --output-document=pywin32-224-cp27-none-win_amd64.whl
+- wine c:\\Python27\\python.exe -m pip install pywin32-224-cp27-none-win_amd64.whl
 - wine c:\\Python27\\python.exe -m pip install pyinstaller -r requirements.txt
 - wine c:\\Python27\\Scripts\\pyinstaller --noconsole --onefile Windows/lazagne.spec
-- sleep 2  # Give PyInstaller two seconds to finish writing to stdout
 - ls -l dist  # See file size (4.8 mb), etc.
 install: true  # do not repeat `pip install -r requirements.txt`
 script:

--- a/Linux/requirement.txt
+++ b/Linux/requirement.txt
@@ -1,3 +1,0 @@
-pyasn1
-psutil
-secretstorage

--- a/Windows/requirement.txt
+++ b/Windows/requirement.txt
@@ -1,4 +1,0 @@
-pyasn1
-enum34
-rsa
-https://github.com/AlessandroZ/pypykatz/archive/master.zip # should point to pypykatz if my PR is approved


### PR DESCRIPTION
Is is OK to drop __pywin32-224-cp27-none-win_amd64.whl__ or not?

If not, is it OK to pip install it?  https://pypi.org/project/pywin32