### PR TITLE
Automatic join all other additional profiles.

### DIFF
--- a/Windows/lazagne/softwares/browsers/chromium_based.py
+++ b/Windows/lazagne/softwares/browsers/chromium_based.py
@@ -31,6 +31,11 @@ class ChromiumBased(ModuleInfo):
             if os.path.exists(profiles_path):
                 # List all users profile (empty string means current dir, without a profile)
                 profiles = {'Default', ''}
+                # Automatic join all other additional profiles
+                for dirs in os.listdir(path):
+                    dirs_path = os.path.join(path, dirs)
+                    if (os.path.isdir(dirs_path) == True) & (dirs.startswith('Profile')):
+                        profiles.extend(dirs)
                 with open(profiles_path) as f:
                     try:
                         data = json.load(f)


### PR DESCRIPTION
https://www.howtogeek.com/255653/how-to-find-your-chrome-profile-folder-on-windows-mac-and-linux/
Any newly created profiles directory would be named "Profile X", which was missed by this script.