### PR TITLE
Fixing a bug trying to dump Chrome credentials, after dumping keychai…

### DIFF
--- a/Mac/lazagne/config/run.py
+++ b/Mac/lazagne/config/run.py
@@ -141,7 +141,7 @@ def run_lazagne(category_selected='all', subcategories={}, password=None, intera
     # If keychains has been decrypted, launch again some module
     chrome_key = get_safe_storage_key('Chrome Safe Storage')
     if chrome_key:
-        for r in run_module({'chrome': Chrome(safe_storage_key=chrome_key)}):
+        for r in run_module({'chrome': Chrome(safe_storage_key=chrome_key)}, subcategories):
             yield r
 
     constant.stdout_result.append(constant.finalResults)


### PR DESCRIPTION
When dumping keychain credentials, the script tries to get password from Chrome but the module is not called with the right parameters. 

Now the parameters are defined right. 