### PR TITLE
Travis CI: Let's pass the lint tests on Python 3 again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ lint_steps: &lint_steps
   before_install:
     - pip install --upgrade pip
     - pip install flake8
-  script: flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics --builtins="unicode"
+  script: flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ lint_steps: &lint_steps
   script: flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics --builtins="unicode"
 
 matrix:
-  allow_failures:
-    - python: '3.7'
   include:
     - name: "Test and deploy on Python 2.7"
       python: '2.7'

--- a/Linux/lazagne/config/crypto/pyDes.py
+++ b/Linux/lazagne/config/crypto/pyDes.py
@@ -86,6 +86,11 @@ Note: This code was not written for high-end systems needing a fast
 
 import sys
 
+try:
+    unicode
+except NameError:
+    unicode = str
+
 # _pythonMajorVersion is used to handle Python2 and Python3 differences.
 _pythonMajorVersion = sys.version_info[0]
 
@@ -123,7 +128,6 @@ class _baseDes(object):
         self._iv = IV
         self._padding = pad
         self._padmode = padmode
-
     def getKey(self):
         """getKey() -> bytes"""
         return self.__key

--- a/Linux/lazagne/config/crypto/pyDes.py
+++ b/Linux/lazagne/config/crypto/pyDes.py
@@ -86,11 +86,6 @@ Note: This code was not written for high-end systems needing a fast
 
 import sys
 
-try:
-    unicode
-except NameError:
-    unicode = str
-
 # _pythonMajorVersion is used to handle Python2 and Python3 differences.
 _pythonMajorVersion = sys.version_info[0]
 
@@ -235,7 +230,7 @@ class _baseDes(object):
         # Only accept byte strings or ascii unicode values, otherwise
         # there is no way to correctly decode the data into bytes.
         if _pythonMajorVersion < 3:
-            if isinstance(data, unicode):
+            if isinstance(data, unicode):  # noqa
                 raise ValueError("pyDes can only work with bytes, not Unicode strings.")
         else:
             if isinstance(data, str):

--- a/Linux/lazagne/config/crypto/pyaes/aes.py
+++ b/Linux/lazagne/config/crypto/pyaes/aes.py
@@ -74,7 +74,7 @@ def _concat_list(a, b):
 # Python 3 compatibility
 try:
     xrange
-except Exception:
+except NameError:
     xrange = range
 
     # Python 3 supports bytes, which is already an array of integers

--- a/Linux/lazagne/config/crypto/pyaes/util.py
+++ b/Linux/lazagne/config/crypto/pyaes/util.py
@@ -34,7 +34,7 @@ def _get_byte(c):
 
 try:
     xrange
-except:
+except NameError:
 
     def to_bufferable(binary):
         if isinstance(binary, bytes):

--- a/Mac/lazagne/config/crypto/pyDes.py
+++ b/Mac/lazagne/config/crypto/pyDes.py
@@ -231,7 +231,7 @@ class _baseDes(object):
         # Only accept byte strings or ascii unicode values, otherwise
         # there is no way to correctly decode the data into bytes.
         if _pythonMajorVersion < 3:
-            if isinstance(data, unicode):
+            if isinstance(data, unicode):  # noqa
                 raise ValueError("pyDes can only work with bytes, not Unicode strings.")
         else:
             if isinstance(data, str):

--- a/Windows/lazagne/config/crypto/pyDes.py
+++ b/Windows/lazagne/config/crypto/pyDes.py
@@ -229,7 +229,7 @@ class _baseDes(object):
         # Only accept byte strings or ascii unicode values, otherwise
         # there is no way to correctly decode the data into bytes.
         if _pythonMajorVersion < 3:
-            if isinstance(data, unicode):
+            if isinstance(data, unicode):  # noqa
                 raise ValueError("pyDes can only work with bytes, not Unicode strings.")
         else:
             if isinstance(data, str):


### PR DESCRIPTION
Remove Python 3 __allow_failures__ mode from Travis CI