### PR TITLE
If fail to get username via winapi

### DIFF
--- a/Windows/lazagne/config/users.py
+++ b/Windows/lazagne/config/users.py
@@ -76,6 +76,6 @@ def get_username_winapi():
             size.value = len(_buffer)
         
         else:
-            return # Unusual error
+            return os.getenv('username') # Unusual error
 
     return _buffer.value


### PR DESCRIPTION
Hi!

>   File "~\lazagne\config\run.py", line 189, in run_lazagne
> AttributeError: 'NoneType' object has no attribute 'endswith'