### PR TITLE
fix wifi output order

### DIFF
--- a/Linux/lazagne/config/write_output.py
+++ b/Linux/lazagne/config/write_output.py
@@ -11,6 +11,8 @@ from lazagne.config.constant import constant
 from platform import uname
 from time import gmtime, strftime
 
+from collections import OrderedDict
+
 
 class Bcolors():
     HEADER = '\033[95m'
@@ -143,7 +145,7 @@ class StandardOutput():
             to_write = []
 
             # Remove duplicated password
-            pwd_found = [dict(t) for t in set([tuple(d.items()) for d in pwd_found])]
+            pwd_found = [OrderedDict(t) for t in set([tuple(d.items()) for d in pwd_found])]
 
             for pwd in pwd_found:
                 password_category = False

--- a/Linux/lazagne/softwares/wifi/wifi.py
+++ b/Linux/lazagne/softwares/wifi/wifi.py
@@ -11,6 +11,8 @@ try:
 except ImportError:
     from configparser import RawConfigParser  # Python 3
 
+from collections import OrderedDict
+
 
 class Wifi(ModuleInfo):
     def __init__(self):
@@ -27,7 +29,7 @@ class Wifi(ModuleInfo):
                 for w in wireless_ssid:
                     cp = RawConfigParser()
                     cp.read(os.path.join(directory, w))
-                    values = {}
+                    values = OrderedDict()
                     try:
                         values['SSID'] = cp.get('wifi', 'ssid')
                         values['Password'] = cp.get('wifi-security', 'psk')


### PR DESCRIPTION
fixes #420

The same change could be made for other outputs as well, but none (that I see) are as jarring as the WiFi output.

This change is compatible with both Python2 & Python3.