### PR TITLE
improve import statement

### DIFF
--- a/Windows/lazagne/softwares/git/gitforwindows.py
+++ b/Windows/lazagne/softwares/git/gitforwindows.py
@@ -4,7 +4,7 @@ import os
 try: 
     from urlparse import urlparse
 except ImportError: 
-    from urllib import parse as urlparse
+    from urllib.parse import urlparse
 
 from lazagne.config.constant import constant
 from lazagne.config.module_info import ModuleInfo


### PR DESCRIPTION
There was an error in import statement for python3 in gitforwindows.py. So, error have been occurred on collecting credentials for git in python3/windows.