### PR TITLE
Added limited vault support support for Windows 7

### DIFF
--- a/Windows/lazagne/config/winstructure.py
+++ b/Windows/lazagne/config/winstructure.py
@@ -213,19 +213,19 @@ class VAULT_ITEM_WIN8(Structure):
 PVAULT_ITEM_WIN8 = POINTER(VAULT_ITEM_WIN8)
 
 
-# class VAULT_ITEM_WIN7(Structure):
-#   _fields_ = [
-#       ('id',              GUID),
-#       ('pName',           PWSTR),
-#       ('pResource',       PVAULT_ITEM_DATA),
-#       ('pUsername',       PVAULT_ITEM_DATA),
-#       ('pPassword',       PVAULT_ITEM_DATA),
-#       ('LastWritten',     FILETIME),
-#       ('Flags',           DWORD),
-#       ('cbProperties',    DWORD),
-#       ('Properties',      PVAULT_ITEM_DATA),
-#   ]
-# PVAULT_ITEM_WIN7 = POINTER(VAULT_ITEM_WIN7)
+class VAULT_ITEM_WIN7(Structure):
+  _fields_ = [
+      ('id',              GUID),
+      ('pName',           PWSTR),
+      ('pResource',       PVAULT_ITEM_DATA),
+      ('pUsername',       PVAULT_ITEM_DATA),
+      ('pPassword',       PVAULT_ITEM_DATA),
+      ('LastWritten',     FILETIME),
+      ('Flags',           DWORD),
+      ('cbProperties',    DWORD),
+      ('Properties',      PVAULT_ITEM_DATA),
+  ]
+PVAULT_ITEM_WIN7 = POINTER(VAULT_ITEM_WIN7)
 
 class OSVERSIONINFOEXW(Structure):
     _fields_ = [
@@ -421,8 +421,8 @@ try:
                             POINTER(PVAULT_ITEM_WIN8))
     vaultGetItem8 = prototype(("VaultGetItem", windll.vaultcli))
 
-    # prototype = WINFUNCTYPE(ULONG, HANDLE, LPGUID, PVAULT_ITEM_DATA, PVAULT_ITEM_DATA, HWND, DWORD, POINTER(PVAULT_ITEM_WIN7))
-    # vaultGetItem7 = prototype(("VaultGetItem", windll.vaultcli))
+    prototype = WINFUNCTYPE(ULONG, HANDLE, LPGUID, PVAULT_ITEM_DATA, PVAULT_ITEM_DATA, HWND, DWORD, POINTER(PVAULT_ITEM_WIN7))
+    vaultGetItem7 = prototype(("VaultGetItem", windll.vaultcli))
 
     prototype = WINFUNCTYPE(ULONG, LPVOID)
     vaultFree = prototype(("VaultFree", windll.vaultcli))

--- a/Windows/lazagne/config/winstructure.py
+++ b/Windows/lazagne/config/winstructure.py
@@ -202,7 +202,7 @@ class VAULT_ITEM_WIN8(Structure):
         ('pResource', PVAULT_ITEM_DATA),
         ('pUsername', PVAULT_ITEM_DATA),
         ('pPassword', PVAULT_ITEM_DATA),
-        ('unknown0', PVAULT_ITEM_DATA),
+        ('pPackageSid', PVAULT_ITEM_DATA),
         ('LastWritten', FILETIME),
         ('Flags', DWORD),
         ('cbProperties', DWORD),

--- a/Windows/lazagne/softwares/windows/vault.py
+++ b/Windows/lazagne/softwares/windows/vault.py
@@ -45,7 +45,7 @@ class Vault(ModuleInfo):
                                             values['Name'] = items8[j].pName
 
                                         if vaultGetItem8(hVault, byref(items8[j].id), items8[j].pResource,
-                                                         items8[j].pUsername, items8[j].unknown0, None, 0,
+                                                         items8[j].pUsername, items8[j].pPackageSid, None, 0,
                                                          byref(pItem8)) == 0:
 
                                             password = pItem8.contents.pPassword.contents.data.string

--- a/Windows/lazagne/softwares/windows/vault.py
+++ b/Windows/lazagne/softwares/windows/vault.py
@@ -35,7 +35,7 @@ class Vault(ModuleInfo):
                                 for j in range(cbItems.value):
 
                                     items8 = cast(items, POINTER(VAULT_ITEM_WIN8))
-                                    pItem8 = PVAULT_ITEM_WIN8()
+                                    pPasswordVaultItem8 = PVAULT_ITEM_WIN8()
                                     try:
                                         values = {
                                             'URL': str(items8[j].pResource.contents.data.string),
@@ -46,9 +46,9 @@ class Vault(ModuleInfo):
 
                                         if vaultGetItem8(hVault, byref(items8[j].id), items8[j].pResource,
                                                          items8[j].pUsername, items8[j].pPackageSid, None, 0,
-                                                         byref(pItem8)) == 0:
+                                                         byref(pPasswordVaultItem8)) == 0:
 
-                                            password = pItem8.contents.pPassword.contents.data.string
+                                            password = pPasswordVaultItem8.contents.pPassword.contents.data.string
                                             # Remove password too long
                                             if password and len(password) < 100:
                                                 values['Password'] = password
@@ -58,8 +58,8 @@ class Vault(ModuleInfo):
                                     except Exception as e:
                                         self.debug(e)
 
-                                    if pItem8:
-                                        vaultFree(pItem8)
+                                    if pPasswordVaultItem8:
+                                        vaultFree(pPasswordVaultItem8)
 
                                 if items:
                                     vaultFree(items)

--- a/Windows/lazagne/softwares/windows/vault.py
+++ b/Windows/lazagne/softwares/windows/vault.py
@@ -11,7 +11,7 @@ class Vault(ModuleInfo):
     def run(self):
 
         # retrieve passwords (IE, etc.) using the Windows Vault API
-        if float(get_os_version()) <= 6.1:
+        if float(get_os_version()) < 6.1:
             self.info(u'Vault not supported for this OS')
             return
 
@@ -19,7 +19,7 @@ class Vault(ModuleInfo):
         vaults = LPGUID()
         hVault = HANDLE(INVALID_HANDLE_VALUE)
         cbItems = DWORD()
-        items = c_char_p()
+        items_buf = c_char_p()
         pwd_found = []
 
         if vaultEnumerateVaults(0, byref(cbVaults), byref(vaults)) == 0:
@@ -27,28 +27,27 @@ class Vault(ModuleInfo):
                 self.debug(u'No Vaults found')
                 return
             else:
+                VAULT_ITEM_WIN, PVAULT_ITEM_WIN, VaultGetItemFunc = get_vault_objects_for_this_version_of_windows()
                 for i in range(cbVaults.value):
                     if vaultOpenVault(byref(vaults[i]), 0, byref(hVault)) == 0:
                         if hVault:
-                            if vaultEnumerateItems(hVault, 0x200, byref(cbItems), byref(items)) == 0:
+                            if vaultEnumerateItems(hVault, 0x200, byref(cbItems), byref(items_buf)) == 0:
 
                                 for j in range(cbItems.value):
 
-                                    items8 = cast(items, POINTER(VAULT_ITEM_WIN8))
-                                    pPasswordVaultItem8 = PVAULT_ITEM_WIN8()
+                                    items = cast(items_buf, POINTER(VAULT_ITEM_WIN))
+                                    pPasswordVaultItem = PVAULT_ITEM_WIN()
                                     try:
                                         values = {
-                                            'URL': str(items8[j].pResource.contents.data.string),
-                                            'Login': str(items8[j].pUsername.contents.data.string)
+                                            'URL': str(items[j].pResource.contents.data.string),
+                                            'Login': str(items[j].pUsername.contents.data.string)
                                         }
-                                        if items8[j].pName:
-                                            values['Name'] = items8[j].pName
+                                        if items[j].pName:
+                                            values['Name'] = items[j].pName
 
-                                        if vaultGetItem8(hVault, byref(items8[j].id), items8[j].pResource,
-                                                         items8[j].pUsername, items8[j].pPackageSid, None, 0,
-                                                         byref(pPasswordVaultItem8)) == 0:
+                                        if VaultGetItemFunc(hVault, items[j], pPasswordVaultItem) == 0:
 
-                                            password = pPasswordVaultItem8.contents.pPassword.contents.data.string
+                                            password = pPasswordVaultItem.contents.pPassword.contents.data.string
                                             # Remove password too long
                                             if password and len(password) < 100:
                                                 values['Password'] = password
@@ -58,11 +57,11 @@ class Vault(ModuleInfo):
                                     except Exception as e:
                                         self.debug(e)
 
-                                    if pPasswordVaultItem8:
-                                        vaultFree(pPasswordVaultItem8)
+                                    if pPasswordVaultItem:
+                                        vaultFree(pPasswordVaultItem)
 
-                                if items:
-                                    vaultFree(items)
+                                if items_buf:
+                                    vaultFree(items_buf)
 
                             vaultCloseVault(byref(hVault))
 


### PR DESCRIPTION
For Windows 7 collects logins only from Vault, not passwords. Behaviour for later versions of windows has not been changed (logins and passwords successfully collected).
Password's collecting for Win 7 fails for some reason on function _VaultGetItem_ ([https://github.com/MyLoginOnGitHub/LaZagne/blob/7727bc3bab2d228e5257804088f7f56202d2828d/Windows/lazagne/softwares/windows/vault.py#L48](url)) with status code 87 (ERROR_INVALID_PARAMETER, https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes--0-499-).

I've done as in following, but it fails.
https://github.com/EmpireProject/Empire/blob/master/data/module_source/credentials/Get-VaultCredential.ps1
https://github.com/byt3bl33d3r/SILENTTRINITY/blob/master/silenttrinity/core/teamserver/modules/boo/src/dumpVaultCredentials.boo
https://github.com/danieljoos/winvault/blob/master/syscall.go

I hope later someone could fix this problem. I suggest now to collects only logins for Windows 7 and create issue to fix this later.