### PR TITLE
Changes Encoding of output

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ Supported software
 | PHP | Composer<br> |  |  |
 | SVN | Tortoise  | | |
 | Sysadmin | Apache Directory Studio<br> CoreFTP<br> CyberDuck<br> FileZilla<br> FileZilla Server<br> FTPNavigator<br> OpenSSH<br> OpenVPN<br> KeePass Configuration Files (KeePass1, KeePass2)<br> PuttyCM<br>RDPManager<br> VNC<br> WinSCP<br> Windows Subsystem for Linux | Apache Directory Studio<br> AWS<br>  Docker<br> Environnement variable<br> FileZilla<br> gFTP<br> History files<br> Shares <br> SSH private keys <br> KeePass Configuration Files (KeePassX, KeePass2) <br> Grub |  |
-| Wifi | Wireless Network | Network Manager<br> WPA Supplicant |  ||  |
 | Wifi | Wireless Network | Network Manager<br> WPA Supplicant |  |
 | Internal mechanism passwords storage | Autologon<br> MSCache<br> Credential Files<br> Credman <br> DPAPI Hash <br> Hashdump (LM/NT)<br> LSA secret<br> Vault Files | GNOME Keyring<br> Kwallet<br> Hashdump | Keychains<br> Hashdump |
 

--- a/Windows/lazagne/config/write_output.py
+++ b/Windows/lazagne/config/write_output.py
@@ -330,7 +330,7 @@ def write_in_file(result):
                 # Human readable Json format
                 pretty_json = json.dumps(result, sort_keys=True, indent=4, separators=(',', ': '), ensure_ascii=False)
                 with open(os.path.join(constant.folder_name, constant.file_name_results + '.json'), 'ab+') as f:
-                    f.write(pretty_json.encode())
+                    f.write(pretty_json.encode(encoding='UTF-8',errors="xmlcharrefreplace"))
 
                 constant.st.do_print(u'[+] File written: {file}'.format(
                     file=os.path.join(constant.folder_name, constant.file_name_results + '.json'))
@@ -342,7 +342,7 @@ def write_in_file(result):
             try:
                 with open(os.path.join(constant.folder_name, constant.file_name_results + '.txt'), 'ab+') as f:
                     a = json_to_string(result)
-                    f.write(a.encode())
+                    f.write(a.encode(encoding='UTF-8',errors="xmlcharrefreplace"))
 
                 constant.st.write_footer()
                 constant.st.do_print(u'[+] File written: {file}'.format(


### PR DESCRIPTION
When writing out passwords containing unicode characters the log used to write junk.
Fixes #486