### PR TITLE
update version in contant.py

### DIFF
--- a/Linux/lazagne/config/constant.py
+++ b/Linux/lazagne/config/constant.py
@@ -9,7 +9,7 @@ class constant():
     folder_name         = 'results_{current_time}'.format(current_time=date)
     file_name_results   = 'credentials'  # The extension is added depending on the user output choice
     max_help   = 27
-    CURRENT_VERSION     = '1.4.3'
+    CURRENT_VERSION     = '2.4.3'
     output              = None
     file_logger         = None
     verbose             = False

--- a/Mac/lazagne/config/constant.py
+++ b/Mac/lazagne/config/constant.py
@@ -7,23 +7,23 @@ date = time.strftime("%d%m%Y_%H%M%S")
 
 
 class constant():
-    folder_name 		= '.'
-    file_name_results 	= 'credentials_{current_time}'.format(current_time=date)  # extension added (txt, json)
-    MAX_HELP_POSITION 	= 27
-    CURRENT_VERSION 	= '2.4.3'
-    output 				= None
-    file_logger 		= None
-    verbose 			= False
-    nbPasswordFound 	= 0			# total password found
-    passwordFound 		= []
-    keychains_pwd 		= []		# password of the keychain
-    keychains_pwds 		= []		# passwords contained in the keychain
-    system_pwd 			= []
-    finalResults 		= {}
-    quiet_mode 			= False
-    st 					= None 		# standard output
-    dictionary_attack 	= False
-    user_password		= None
+    folder_name         = '.'
+    file_name_results   = 'credentials_{current_time}'.format(current_time=date)  # extension added (txt, json)
+    MAX_HELP_POSITION   = 27
+    CURRENT_VERSION     = '2.4.3'
+    output              = None
+    file_logger         = None
+    verbose             = False
+    nbPasswordFound     = 0         # total password found
+    passwordFound       = []
+    keychains_pwd       = []        # password of the keychain
+    keychains_pwds      = []        # passwords contained in the keychain
+    system_pwd          = []
+    finalResults        = {}
+    quiet_mode          = False
+    st                  = None      # standard output
+    dictionary_attack   = False
+    user_password       = None
     user_keychain_find 	= False
-    stdout_result		= []  # Tab containing all results by user
-    modules_dic			= {}
+    stdout_result       = []        # Tab containing all results by user
+    modules_dic         = {}

--- a/Mac/lazagne/config/constant.py
+++ b/Mac/lazagne/config/constant.py
@@ -10,7 +10,7 @@ class constant():
     folder_name 		= '.'
     file_name_results 	= 'credentials_{current_time}'.format(current_time=date)  # extension added (txt, json)
     MAX_HELP_POSITION 	= 27
-    CURRENT_VERSION 	= '0.3.2'
+    CURRENT_VERSION 	= '2.4.3'
     output 				= None
     file_logger 		= None
     verbose 			= False


### PR DESCRIPTION
The Linux and Mac version constant hadn't been updated in a while, resulting in an older version number being printed when executing `./laZagne.py --version`.