### PR TITLE
fix chrome password retrieval on linux

### DIFF
--- a/Linux/lazagne/softwares/wallet/libsecret.py
+++ b/Linux/lazagne/softwares/wallet/libsecret.py
@@ -91,7 +91,7 @@ class Libsecret(ModuleInfo):
                     # for k, v in item.get_attributes().iteritems():
                     #   values[unicode(k)] = unicode(v)
                     items.append(values)
-                    if item.get_label() == 'Chromium Safe Storage':
+                    if item.get_label() == 'Chrome Safe Storage' || item.get_label() == 'Chromium Safe Storage':
                         constant.chrome_storage = item.get_secret()
 
             try:


### PR DESCRIPTION
When Chrome is the only Chromium browser installed on a system, there will not be a secret called "Chromium Safe Storage". Instead, it is called "Chrome Safe Storage".

Fixes https://github.com/AlessandroZ/LaZagne/issues/489