### PR TITLE
Reworked Chrome code to support Chromium-based browsers

### DIFF
--- a/Linux/lazagne/config/constant.py
+++ b/Linux/lazagne/config/constant.py
@@ -20,4 +20,9 @@ class constant():
     quiet_mode          = False
     st                  = None  # Standard output
     modules_dic         = {}
-    chrome_storage      = None # Retrieved from libsecrets module
+    chrome_storage      = [] # Retrieved from libsecrets module
+    chrome_dirs         = [
+     u'.config/google-chrome',
+     u'.config/chromium',
+     u'.config/BraveSoftware/Brave-Browser'
+    ]

--- a/Linux/lazagne/softwares/browsers/chrome.py
+++ b/Linux/lazagne/softwares/browsers/chrome.py
@@ -28,7 +28,7 @@ class Chrome(ModuleInfo):
         self.AES_BLOCK_SIZE = 16
 
     def get_paths(self):
-        for profile_dir in homes.get(directory=[u'.config/google-chrome', u'.config/chromium']):
+        for profile_dir in homes.get(directory=constant.chrome_dirs):
             try:
                 subdirs = os.listdir(profile_dir)
             except Exception:
@@ -76,22 +76,30 @@ class Chrome(ModuleInfo):
 
                     # To decrypt it, Chromium Safe Storage from libsecret module is needed
                     if not constant.chrome_storage:
-                        self.info('Password encrypted and chrome secret storage not found')
+                        self.info('Password encrypted and Chrome Secret Storage not found')
                         continue
 
                     else:
+                        psswrd = password
                         try:
-                            enc_key = pbkdf2_hmac(
-                                hash_name='sha1', 
-                                password=constant.chrome_storage, 
-                                salt=self.enc_config['salt'], 
-                                iterations=self.enc_config['iterations'], 
-                                dklen=self.enc_config['length'])
+                            for css in constant.chrome_storage:
+                              enc_key = pbkdf2_hmac(
+                                  hash_name='sha1', 
+                                  password=css, 
+                                  salt=self.enc_config['salt'], 
+                                  iterations=self.enc_config['iterations'], 
+                                  dklen=self.enc_config['length'])
 
-                            password = self.chrome_decrypt(password, key=enc_key, init_vector=self.enc_config['iv'])
-                            password = password if python_version == 2 else password.decode()
+                              password = self.chrome_decrypt(password, key=enc_key, init_vector=self.enc_config['iv'])
+                              password = password if python_version == 2 else password.decode()
+                              if password:
+                                  break
+                              else:
+                                  password = psswrd
+
                         except Exception:
                             print(traceback.format_exc())
+
                 if user:
                     yield {
                         'URL': url,

--- a/Linux/lazagne/softwares/wallet/libsecret.py
+++ b/Linux/lazagne/softwares/wallet/libsecret.py
@@ -91,8 +91,8 @@ class Libsecret(ModuleInfo):
                     # for k, v in item.get_attributes().iteritems():
                     #   values[unicode(k)] = unicode(v)
                     items.append(values)
-                    if item.get_label() == 'Chrome Safe Storage' or item.get_label() == 'Chromium Safe Storage':
-                        constant.chrome_storage = item.get_secret()
+                    if item.get_label().endswith('Safe Storage'):
+                        constant.chrome_storage.append(item.get_secret())
 
             try:
                 bus.flush()

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Supported software
 
 |  | Windows    | Linux  | Mac |
 | -- | -- | -- | -- |
-| Browsers | 7Star<br> Amigo<br> BlackHawk<br> Brave<br> Centbrowser<br> Chedot<br> Chrome Canary<br> Chromium<br> Coccoc<br> Comodo Dragon<br> Comodo IceDragon<br> Cyberfox<br> Elements Browser<br> Epic Privacy Browser<br> Firefox<br> Google Chrome<br> Icecat<br> K-Meleon<br> Kometa<br> Opera<br> Orbitum<br> Sputnik<br> Torch<br> Uran<br> Vivaldi<br> | Chrome<br> Firefox<br> Opera | Chrome<br> Firefox |
+| Browsers | 7Star<br> Amigo<br> BlackHawk<br> Brave<br> Centbrowser<br> Chedot<br> Chrome Canary<br> Chromium<br> Coccoc<br> Comodo Dragon<br> Comodo IceDragon<br> Cyberfox<br> Elements Browser<br> Epic Privacy Browser<br> Firefox<br> Google Chrome<br> Icecat<br> K-Meleon<br> Kometa<br> Opera<br> Orbitum<br> Sputnik<br> Torch<br> Uran<br> Vivaldi<br> | Brave<br> Chromium<br> Google Chrome<br> Firefox<br> Opera | Chrome<br> Firefox |
 | Chats | Pidgin<br> Psi<br> Skype| Pidgin<br> Psi |  |
 | Databases | DBVisualizer<br> Postgresql<br> Robomongo<br> Squirrel<br> SQLdevelopper | DBVisualizer<br> Squirrel<br> SQLdevelopper  |  |
 | Games | GalconFusion<br> Kalypsomedia<br> RogueTale<br> Turba |  |  |


### PR DESCRIPTION
Currently tested with Brave, but it should work with others as well.
This also completes support for Chromium now, which was only partially working before.

To add others, just add their config directory to `constant.chrome_dirs`