### PR TITLE
Divide Chromium-based browser passwords according to browser

### DIFF
--- a/Linux/lazagne/config/constant.py
+++ b/Linux/lazagne/config/constant.py
@@ -21,8 +21,3 @@ class constant():
     st                  = None  # Standard output
     modules_dic         = {}
     chrome_storage      = [] # Retrieved from libsecrets module
-    chrome_dirs         = [
-     u'.config/google-chrome',
-     u'.config/chromium',
-     u'.config/BraveSoftware/Brave-Browser'
-    ]

--- a/Linux/lazagne/config/manage_modules.py
+++ b/Linux/lazagne/config/manage_modules.py
@@ -6,7 +6,7 @@ from lazagne.softwares.wallet.libsecret import Libsecret
 # browsers
 from lazagne.softwares.browsers.mozilla import firefox_browsers
 from lazagne.softwares.browsers.opera import Opera
-from lazagne.softwares.browsers.chrome import Chrome
+from lazagne.softwares.browsers.chrome import chrome_browsers
 # sysadmin
 from lazagne.softwares.sysadmin.apachedirectorystudio import ApacheDirectoryStudio
 from lazagne.softwares.sysadmin.filezilla import Filezilla
@@ -71,7 +71,7 @@ def get_modules():
         Fstab(),
         # Mozilla(),
         Opera(),
-        Chrome(),
+        #Chrome(),
         Pidgin(),
         PSI(),
         Shadow(),
@@ -98,4 +98,4 @@ def get_modules():
     # except:
     # 	pass
 
-    return module_names + firefox_browsers
+    return module_names + chrome_browsers + firefox_browsers

--- a/Linux/lazagne/softwares/browsers/chrome.py
+++ b/Linux/lazagne/softwares/browsers/chrome.py
@@ -17,8 +17,9 @@ from lazagne.softwares.browsers.mozilla import python_version
 
 
 class Chrome(ModuleInfo):
-    def __init__(self):
-        ModuleInfo.__init__(self, 'chrome', 'browsers')
+    def __init__(self, browser_name, path):
+        self.path = path
+        ModuleInfo.__init__(self, browser_name, category='browsers')
         self.enc_config = {
             'iv': b' ' * 16,
             'length': 16,
@@ -28,7 +29,7 @@ class Chrome(ModuleInfo):
         self.AES_BLOCK_SIZE = 16
 
     def get_paths(self):
-        for profile_dir in homes.get(directory=constant.chrome_dirs):
+        for profile_dir in homes.get(directory=self.path):
             try:
                 subdirs = os.listdir(profile_dir)
             except Exception:
@@ -125,3 +126,13 @@ class Chrome(ModuleInfo):
                 all_passwords.append(pw)
 
         return all_passwords
+
+
+# Name, path
+chrome_browsers = [
+    (u'Google Chrome', u'.config/google-chrome'),
+    (u'Chromium', u'.config/chromium'),
+    (u'Brave', u'.config/BraveSoftware/Brave-Browser'),
+]
+
+chrome_browsers = [Chrome(browser_name=name, path=path) for name, path in chrome_browsers]


### PR DESCRIPTION
Since we're now collecting passwords from multiple chromium-based browsers, it makes sense to give each one it's own section, similar to Firefox.