### PR TITLE
Add support for more browsers on Linux

### DIFF
--- a/Linux/lazagne/softwares/browsers/chrome.py
+++ b/Linux/lazagne/softwares/browsers/chrome.py
@@ -133,6 +133,11 @@ chrome_browsers = [
     (u'Google Chrome', u'.config/google-chrome'),
     (u'Chromium', u'.config/chromium'),
     (u'Brave', u'.config/BraveSoftware/Brave-Browser'),
+    (u'SlimJet', u'.config/slimjet'),
+    (u'Dissenter Browser', u'.config/GabAI/Dissenter-Browser'),
+    # (u'SuperBird', u'.config/superbird'),  # FIXME
+    # (u'Vivaldi', u'.config/vivaldi'),  # FIXME returns bytes
+    # (u'Whale', u'.config/naver-whale'),  # FIXME returns bytes
 ]
 
 chrome_browsers = [Chrome(browser_name=name, path=path) for name, path in chrome_browsers]

--- a/Linux/lazagne/softwares/browsers/mozilla.py
+++ b/Linux/lazagne/softwares/browsers/mozilla.py
@@ -551,12 +551,9 @@ class Mozilla(ModuleInfo):
 # Name, path
 firefox_browsers = [
     (u'firefox', u'.mozilla/firefox'),
-    # Check these paths on Linux systems
-    # (u'blackHawk', u'{APPDATA}\\NETGATE Technologies\\BlackHawk'),
-    # (u'cyberfox', u'{APPDATA}\\8pecxstudios\\Cyberfox'),
-    # (u'comodo icedragon', u'{APPDATA}\\Comodo\\IceDragon'),
-    # (u'k-meleon', u'{APPDATA}\\K-Meleon'),
-    # (u'icecat', u'{APPDATA}\\Mozilla\\icecat'),
+    (u'icecat', u'.mozilla/icecat'),
+    (u'waterfox', u'.waterfox'),
+    # (u'Pale Moon', u'.moonchild productions/pale moon'), FIXME
 ]
 
 firefox_browsers = [Mozilla(browser_name=name, path=path) for name, path in firefox_browsers]

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Supported software
 
 |  | Windows    | Linux  | Mac |
 | -- | -- | -- | -- |
-| Browsers | 7Star<br> Amigo<br> BlackHawk<br> Brave<br> Centbrowser<br> Chedot<br> Chrome Canary<br> Chromium<br> Coccoc<br> Comodo Dragon<br> Comodo IceDragon<br> Cyberfox<br> Elements Browser<br> Epic Privacy Browser<br> Firefox<br> Google Chrome<br> Icecat<br> K-Meleon<br> Kometa<br> Opera<br> Orbitum<br> Sputnik<br> Torch<br> Uran<br> Vivaldi<br> | Brave<br> Chromium<br> Google Chrome<br> Firefox<br> Opera | Chrome<br> Firefox |
+| Browsers | 7Star<br> Amigo<br> BlackHawk<br> Brave<br> Centbrowser<br> Chedot<br> Chrome Canary<br> Chromium<br> Coccoc<br> Comodo Dragon<br> Comodo IceDragon<br> Cyberfox<br> Elements Browser<br> Epic Privacy Browser<br> Firefox<br> Google Chrome<br> Icecat<br> K-Meleon<br> Kometa<br> Opera<br> Orbitum<br> Sputnik<br> Torch<br> Uran<br> Vivaldi<br> | Brave<br> Chromium<br> Dissenter-Browser<br> Google Chrome<br> IceCat<br> Firefox<br> Opera<br> SlimJet<br> WaterFox | Chrome<br> Firefox |
 | Chats | Pidgin<br> Psi<br> Skype| Pidgin<br> Psi |  |
 | Databases | DBVisualizer<br> Postgresql<br> Robomongo<br> Squirrel<br> SQLdevelopper | DBVisualizer<br> Squirrel<br> SQLdevelopper  |  |
 | Games | GalconFusion<br> Kalypsomedia<br> RogueTale<br> Turba |  |  |


### PR DESCRIPTION
Chromium-based:
- SlimJet
- Dissenter-Browser

Firefox-based:
- IceCat
- WaterFox

#### Some notes:
I removed Cyberfox because it is an outdated browser which hasn't been updated in several years.
The remaining Firefox-based browser commented out to test are unavailable for Linux.

I also tested several browser which didn't work. I left them commented out with FIXME notations in case someone wants to look at them:
- **SuperBird**: This one had a lot of tracebacks, presumably it uses a different method for storing the passwords than standard Chromium-based browsers.
- **Vivaldi & Whale**: These are a little weird. They each (if included individually, or the last of both if you uncomment both of them) fail at this line. 
https://github.com/AlessandroZ/LaZagne/blob/f5425058102f18a643a5734eeef6a897af182e67/Linux/lazagne/softwares/browsers/chrome.py#L95
- **Pale Moon**: This is a browser based on an old version of Firefox. Perhaps the Firefox code we have only supports newer versions, or maybe they use a different method, but it doesn't work right now.