### PR TITLE
Support Chrome v80+ on Linux

### DIFF
--- a/Linux/lazagne/config/manage_modules.py
+++ b/Linux/lazagne/config/manage_modules.py
@@ -6,7 +6,7 @@ from lazagne.softwares.wallet.libsecret import Libsecret
 # browsers
 from lazagne.softwares.browsers.mozilla import firefox_browsers
 from lazagne.softwares.browsers.opera import Opera
-from lazagne.softwares.browsers.chrome import chrome_browsers
+from lazagne.softwares.browsers.chromium_based import chromium_browsers
 # sysadmin
 from lazagne.softwares.sysadmin.apachedirectorystudio import ApacheDirectoryStudio
 from lazagne.softwares.sysadmin.filezilla import Filezilla
@@ -71,7 +71,7 @@ def get_modules():
         Fstab(),
         # Mozilla(),
         Opera(),
-        #Chrome(),
+        # Chrome(),
         Pidgin(),
         PSI(),
         Shadow(),
@@ -98,4 +98,4 @@ def get_modules():
     # except:
     # 	pass
 
-    return module_names + chrome_browsers + firefox_browsers
+    return module_names + chromium_browsers + firefox_browsers

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Supported software
 
 |  | Windows    | Linux  | Mac |
 | -- | -- | -- | -- |
-| Browsers | 7Star<br> Amigo<br> BlackHawk<br> Brave<br> Centbrowser<br> Chedot<br> Chrome Canary<br> Chromium<br> Coccoc<br> Comodo Dragon<br> Comodo IceDragon<br> Cyberfox<br> Elements Browser<br> Epic Privacy Browser<br> Firefox<br> Google Chrome<br> Icecat<br> K-Meleon<br> Kometa<br> Opera<br> Orbitum<br> Sputnik<br> Torch<br> Uran<br> Vivaldi<br> | Brave<br> Chromium<br> Dissenter-Browser<br> Google Chrome<br> IceCat<br> Firefox<br> Opera<br> SlimJet<br> WaterFox | Chrome<br> Firefox |
+| Browsers | 7Star<br> Amigo<br> BlackHawk<br> Brave<br> Centbrowser<br> Chedot<br> Chrome Canary<br> Chromium<br> Coccoc<br> Comodo Dragon<br> Comodo IceDragon<br> Cyberfox<br> Elements Browser<br> Epic Privacy Browser<br> Firefox<br> Google Chrome<br> Icecat<br> K-Meleon<br> Kometa<br> Opera<br> Orbitum<br> Sputnik<br> Torch<br> Uran<br> Vivaldi<br> | Brave<br> Chromium<br> Dissenter-Browser<br> Google Chrome<br> IceCat<br> Firefox<br> Opera<br> SlimJet<br> Vivaldi<br> WaterFox | Chrome<br> Firefox |
 | Chats | Pidgin<br> Psi<br> Skype| Pidgin<br> Psi |  |
 | Databases | DBVisualizer<br> Postgresql<br> Robomongo<br> Squirrel<br> SQLdevelopper | DBVisualizer<br> Squirrel<br> SQLdevelopper  |  |
 | Games | GalconFusion<br> Kalypsomedia<br> RogueTale<br> Turba |  |  |

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ enum34; python_version < '3.4' and sys_platform == 'win32'
 rsa; sys_platform == 'win32'
 https://github.com/AlessandroZ/pypykatz/archive/master.zip; python_version < '3.4' and sys_platform == 'win32'
 https://github.com/skelsec/pypykatz/archive/master.zip; python_version  > '3.5' and sys_platform == 'win32'
-pycryptodome; sys_platform == 'win32'
+pycryptodome


### PR DESCRIPTION
and add Vivaldi to supported browsers

When Chrome v80 support was added to Windows (#475, https://github.com/AlessandroZ/LaZagne/commit/db3461a26ea7c246f5cee00a7630c4bf7e610861), it wasn't added to Linux. This commit adds it (and its dependency, `pycryptodome`), to Linux. It should also be ported to Mac, but I don't have one to test.

I also renamed the class to `ChromiumBased` to match the Windows version, since it now extracts passwords from many Chromium based browsers, and not just Chrome.

The final change was adding Vivaldi (which didn't work before, #516), since with this update it works for me.