### PR TITLE
Mac LaZagne: Adding two dicts together in Python 3

### DIFF
--- a/Mac/laZagne.py
+++ b/Mac/laZagne.py
@@ -192,7 +192,7 @@ if __name__ == '__main__':
                 parser_tab += categories[c]['subparser']
         parser_tab += [PWrite]
         dic_tmp = {c: {'parents': parser_tab, 'help': 'Run %s module' % c}}
-        dic = dict(dic.items() + dic_tmp.items())
+        dic = dict(list(dic.items()) + list(dic_tmp.items()))
 
     subparsers = parser.add_subparsers(help='Choose a main command')
     for d in dic:


### PR DESCRIPTION
This solution to https://github.com/AlessandroZ/LaZagne/issues/431#issuecomment-552210931 should work in both Python 2 and Python 3.

% `python3`
```
>>> dic = {"A": 0}
>>> dic_tmp = {"B": 1}

>>> dict(dic.items() + dic_tmp.items())
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: unsupported operand type(s) for +: 'dict_items' and 'dict_items'

>>> dict(list(dic.items()) + list(dic_tmp.items()))
{'A': 0, 'B': 1}
```
---
 % `python2`
```
>>> dic = {"A": 0}
>>> dic_tmp = {"B": 1}

>>> dict(dic.items() + dic_tmp.items())
{'A': 0, 'B': 1}

>>> dict(list(dic.items()) + list(dic_tmp.items()))
{'A': 0, 'B': 1}
```