### PR TITLE
Mac LaZagne fix for #431 from hashlib import sha1

### DIFF
--- a/Mac/lazagne/softwares/system/chainbreaker_module/pbkdf2.py
+++ b/Mac/lazagne/softwares/system/chainbreaker_module/pbkdf2.py
@@ -6,16 +6,16 @@
 # (c) 2004 Matt Johnston <matt @ ucc asn au>
 # This code may be freely used and modified for any purpose.
 
-import sha
 import hmac
 
+from hashlib import sha1
 from struct import pack
 
 BLOCKLEN = 20
 
 
 # this is what you want to call.
-def pbkdf2(password, salt, itercount, keylen, hashfn=sha):
+def pbkdf2(password, salt, itercount, keylen, hashfn=sha1):
     # l - number of output blocks to produce
     l = keylen / BLOCKLEN
     if keylen % BLOCKLEN != 0:


### PR DESCRIPTION
Fixes #431

https://docs.python.org/2/library/sha.html is deprecated as sha1() has moved to https://docs.python.org/3/library/hashlib.html

This change should work in both Python 2 and Python 3.