### PR TITLE
Fix condition never met

### DIFF
--- a/Windows/lazagne/softwares/chats/pidgin.py
+++ b/Windows/lazagne/softwares/chats/pidgin.py
@@ -20,7 +20,7 @@ class Pidgin(ModuleInfo):
             for account in root.findall('account'):
                 name = account.find('name')
                 password = account.find('password')
-                if all((name, password)):
+                if None not in (name, password):
                     pwd_found.append({
                         'Login': name.text,
                         'Password': password.text


### PR DESCRIPTION
The condition is never met, even if name and password exist.

![image](https://user-images.githubusercontent.com/11051803/97548834-ed97b800-19cf-11eb-9e0b-a280fa638ba5.png)

Checking if elements are not equal to `None` makes it work.