### PR TITLE
Chromium Support - Fixing variable type

### DIFF
--- a/Windows/lazagne/softwares/browsers/chromium_based.py
+++ b/Windows/lazagne/softwares/browsers/chromium_based.py
@@ -143,7 +143,7 @@ class ChromiumBased(ModuleInfo):
                     # Failed...
                 else:
                     # Decrypt the Password
-                    if password and password.startswith(b'v10'):  # chromium > v80
+                    if password and str(password).startswith(b'v10'):  # chromium > v80
                         if master_key:
                             password = self._decrypt_v80(password, master_key)
                     else:


### PR DESCRIPTION
When running LaZagne with the `-vv` option, trying to dump chromium (edge) password, this results in the following error message:

```
[!] Traceback (most recent call last):
    File "LaZagne\Windows\lazagne\softwares\browsers\chromium_based.py"
      if password and password.startswith(b'v10'): # chromium > v80
AttributeError: 'buffer' object has no attribute 'startswith'
```

When converting the password variable to type string, everything works fine. Tested for Python2.7 and Python3.9.