### PR TITLE
Do not use modules with broken depensences for linux

### DIFF
--- a/Linux/hook-sys.py
+++ b/Linux/hook-sys.py
@@ -1,0 +1,9 @@
+from lazagne.config.manage_modules import get_modules_names
+from lazagne.softwares.browsers.chromium_browsers import chromium_based_module_location
+from lazagne.softwares.browsers.firefox_browsers import mozilla_module_location
+
+all_hidden_imports_module_names = get_modules_names() + [mozilla_module_location, chromium_based_module_location]
+hiddenimports = [package_name for package_name, module_name in all_hidden_imports_module_names]
+
+if __name__ == "__main__":
+    print("\r\n".join(hiddenimports))

--- a/Linux/lazagne/config/constant.py
+++ b/Linux/lazagne/config/constant.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- encoding: utf-8 -*-
+import sys
 import time
 
 date = time.strftime("%d%m%Y_%H%M%S")
@@ -21,3 +22,7 @@ class constant():
     st                  = None  # Standard output
     modules_dic         = {}
     chrome_storage      = [] # Retrieved from libsecrets module
+
+
+if sys.version_info[0]:
+    python_version = sys.version_info[0]

--- a/Linux/lazagne/config/manage_modules.py
+++ b/Linux/lazagne/config/manage_modules.py
@@ -28,34 +28,34 @@ def get_categories():
     return category
 
 
-def get_modules():
-    module_names = [
-        soft_import("lazagne.softwares.mails.clawsmail", "ClawsMail")(),
-        soft_import("lazagne.softwares.mails.thunderbird", "Thunderbird")(),
-        soft_import("lazagne.softwares.databases.dbvis", "DbVisualizer")(),
-        soft_import("lazagne.softwares.sysadmin.env_variable", "Env_variable")(),
-        soft_import("lazagne.softwares.sysadmin.apachedirectorystudio", "ApacheDirectoryStudio")(),
-        soft_import("lazagne.softwares.sysadmin.filezilla", "Filezilla")(),
-        soft_import("lazagne.softwares.sysadmin.fstab", "Fstab")(),
-        soft_import("lazagne.softwares.browsers.opera", "Opera")(),
-        soft_import("lazagne.softwares.chats.pidgin", "Pidgin")(),
-        soft_import("lazagne.softwares.chats.psi", "PSI")(),
-        soft_import("lazagne.softwares.sysadmin.shadow", "Shadow")(),
-        soft_import("lazagne.softwares.sysadmin.aws", "Aws")(),
-        soft_import("lazagne.softwares.sysadmin.docker", "Docker")(),
-        soft_import("lazagne.softwares.sysadmin.ssh", "Ssh")(),
-        soft_import("lazagne.softwares.sysadmin.cli", "Cli")(),
-        soft_import("lazagne.softwares.sysadmin.gftp", "gFTP")(),
-        soft_import("lazagne.softwares.sysadmin.keepassconfig", "KeePassConfig")(),
-        soft_import("lazagne.softwares.sysadmin.grub", "Grub")(),
-        soft_import("lazagne.softwares.databases.sqldeveloper", "SQLDeveloper")(),
-        soft_import("lazagne.softwares.databases.squirrel", "Squirrel")(),
-        soft_import("lazagne.softwares.wifi.wifi", "Wifi")(),
-        soft_import("lazagne.softwares.wifi.wpa_supplicant", "Wpa_supplicant")(),
-        soft_import("lazagne.softwares.wallet.kde", "Kde")(),
-        soft_import("lazagne.softwares.wallet.libsecret", "Libsecret")(),
-        soft_import("lazagne.softwares.memory.mimipy", "Mimipy")(),
-        soft_import("lazagne.softwares.git.gitforlinux", "GitForLinux")()
+def get_modules_names():
+    return [
+        ("lazagne.softwares.mails.clawsmail", "ClawsMail"),
+        ("lazagne.softwares.mails.thunderbird", "Thunderbird"),
+        ("lazagne.softwares.databases.dbvis", "DbVisualizer"),
+        ("lazagne.softwares.sysadmin.env_variable", "Env_variable"),
+        ("lazagne.softwares.sysadmin.apachedirectorystudio", "ApacheDirectoryStudio"),
+        ("lazagne.softwares.sysadmin.filezilla", "Filezilla"),
+        ("lazagne.softwares.sysadmin.fstab", "Fstab"),
+        ("lazagne.softwares.browsers.opera", "Opera"),
+        ("lazagne.softwares.chats.pidgin", "Pidgin"),
+        ("lazagne.softwares.chats.psi", "PSI"),
+        ("lazagne.softwares.sysadmin.shadow", "Shadow"),
+        ("lazagne.softwares.sysadmin.aws", "Aws"),
+        ("lazagne.softwares.sysadmin.docker", "Docker"),
+        ("lazagne.softwares.sysadmin.ssh", "Ssh"),
+        ("lazagne.softwares.sysadmin.cli", "Cli"),
+        ("lazagne.softwares.sysadmin.gftp", "gFTP"),
+        ("lazagne.softwares.sysadmin.keepassconfig", "KeePassConfig"),
+        ("lazagne.softwares.sysadmin.grub", "Grub"),
+        ("lazagne.softwares.databases.sqldeveloper", "SQLDeveloper"),
+        ("lazagne.softwares.databases.squirrel", "Squirrel"),
+        ("lazagne.softwares.wifi.wifi", "Wifi"),
+        ("lazagne.softwares.wifi.wpa_supplicant", "Wpa_supplicant"),
+        ("lazagne.softwares.wallet.kde", "Kde"),
+        ("lazagne.softwares.wallet.libsecret", "Libsecret"),
+        ("lazagne.softwares.memory.mimipy", "Mimipy"),
+        ("lazagne.softwares.git.gitforlinux", "GitForLinux")
     ]
 
     # very long to execute
@@ -64,4 +64,7 @@ def get_modules():
     # except:
     # 	pass
 
-    return module_names + chromium_browsers + firefox_browsers
+
+def get_modules():
+    modules = [soft_import(package_name, module_name)() for package_name, module_name in get_modules_names()]
+    return modules + chromium_browsers + firefox_browsers

--- a/Linux/lazagne/config/manage_modules.py
+++ b/Linux/lazagne/config/manage_modules.py
@@ -1,44 +1,11 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*- 
-# keyring
-from lazagne.softwares.wallet.kde import Kde
-from lazagne.softwares.wallet.libsecret import Libsecret
+# -*- coding: utf-8 -*-
+
+from lazagne.config.soft_import_module import soft_import
 # browsers
-from lazagne.softwares.browsers.mozilla import firefox_browsers
-from lazagne.softwares.browsers.opera import Opera
-from lazagne.softwares.browsers.chromium_based import chromium_browsers
-# sysadmin
-from lazagne.softwares.sysadmin.apachedirectorystudio import ApacheDirectoryStudio
-from lazagne.softwares.sysadmin.filezilla import Filezilla
-from lazagne.softwares.sysadmin.fstab import Fstab
-from lazagne.softwares.sysadmin.env_variable import Env_variable
-from lazagne.softwares.sysadmin.shadow import Shadow
-from lazagne.softwares.sysadmin.aws import Aws
-from lazagne.softwares.sysadmin.ssh import Ssh
-from lazagne.softwares.sysadmin.docker import Docker
-from lazagne.softwares.sysadmin.cli import Cli
-from lazagne.softwares.sysadmin.gftp import gFTP
-from lazagne.softwares.sysadmin.keepassconfig import KeePassConfig
-from lazagne.softwares.sysadmin.grub import Grub
-# chats
-from lazagne.softwares.chats.pidgin import Pidgin
-from lazagne.softwares.chats.psi import PSI
-# mails
-from lazagne.softwares.mails.clawsmail import ClawsMail
-from lazagne.softwares.mails.thunderbird import Thunderbird
-# wifi
-from lazagne.softwares.wifi.wifi import Wifi
-from lazagne.softwares.wifi.wpa_supplicant import Wpa_supplicant
-# databases
-from lazagne.softwares.databases.squirrel import Squirrel
-from lazagne.softwares.databases.dbvis import DbVisualizer
-from lazagne.softwares.databases.sqldeveloper import SQLDeveloper
+from lazagne.softwares.browsers.firefox_browsers import firefox_browsers
+from lazagne.softwares.browsers.chromium_browsers import chromium_browsers
 
-# memory
-from lazagne.softwares.memory.mimipy import Mimipy
-
-# git
-from lazagne.softwares.git.gitforlinux import GitForLinux
 try:
     from lazagne.softwares.memory.memorydump import MemoryDump
 except ImportError:
@@ -55,41 +22,40 @@ def get_categories():
         'wifi': {'help': 'Wifi'},
         'browsers': {'help': 'Web browsers supported'},
         'wallet': {'help': 'Windows credentials (credential manager, etc.)'},
-        'git': {'help': 'GIT clients supported'}
+        'git': {'help': 'GIT clients supported'},
+        'unused': {'help': 'This modules could not be used because of broken dependence'}
     }
     return category
 
 
 def get_modules():
     module_names = [
-        ClawsMail(),
-        Thunderbird(),
-        DbVisualizer(),
-        Env_variable(),
-        ApacheDirectoryStudio(),
-        Filezilla(),
-        Fstab(),
-        # Mozilla(),
-        Opera(),
-        # Chrome(),
-        Pidgin(),
-        PSI(),
-        Shadow(),
-        Aws(),
-        Docker(),
-        Ssh(),
-        Cli(),
-        gFTP(),
-        KeePassConfig(),
-        Grub(),
-        SQLDeveloper(),
-        Squirrel(),
-        Wifi(),
-        Wpa_supplicant(),
-        Kde(),
-        Libsecret(), 
-        Mimipy(),
-        GitForLinux()
+        soft_import("lazagne.softwares.mails.clawsmail", "ClawsMail")(),
+        soft_import("lazagne.softwares.mails.thunderbird", "Thunderbird")(),
+        soft_import("lazagne.softwares.databases.dbvis", "DbVisualizer")(),
+        soft_import("lazagne.softwares.sysadmin.env_variable", "Env_variable")(),
+        soft_import("lazagne.softwares.sysadmin.apachedirectorystudio", "ApacheDirectoryStudio")(),
+        soft_import("lazagne.softwares.sysadmin.filezilla", "Filezilla")(),
+        soft_import("lazagne.softwares.sysadmin.fstab", "Fstab")(),
+        soft_import("lazagne.softwares.browsers.opera", "Opera")(),
+        soft_import("lazagne.softwares.chats.pidgin", "Pidgin")(),
+        soft_import("lazagne.softwares.chats.psi", "PSI")(),
+        soft_import("lazagne.softwares.sysadmin.shadow", "Shadow")(),
+        soft_import("lazagne.softwares.sysadmin.aws", "Aws")(),
+        soft_import("lazagne.softwares.sysadmin.docker", "Docker")(),
+        soft_import("lazagne.softwares.sysadmin.ssh", "Ssh")(),
+        soft_import("lazagne.softwares.sysadmin.cli", "Cli")(),
+        soft_import("lazagne.softwares.sysadmin.gftp", "gFTP")(),
+        soft_import("lazagne.softwares.sysadmin.keepassconfig", "KeePassConfig")(),
+        soft_import("lazagne.softwares.sysadmin.grub", "Grub")(),
+        soft_import("lazagne.softwares.databases.sqldeveloper", "SQLDeveloper")(),
+        soft_import("lazagne.softwares.databases.squirrel", "Squirrel")(),
+        soft_import("lazagne.softwares.wifi.wifi", "Wifi")(),
+        soft_import("lazagne.softwares.wifi.wpa_supplicant", "Wpa_supplicant")(),
+        soft_import("lazagne.softwares.wallet.kde", "Kde")(),
+        soft_import("lazagne.softwares.wallet.libsecret", "Libsecret")(),
+        soft_import("lazagne.softwares.memory.mimipy", "Mimipy")(),
+        soft_import("lazagne.softwares.git.gitforlinux", "GitForLinux")()
     ]
 
     # very long to execute

--- a/Linux/lazagne/config/soft_import_module.py
+++ b/Linux/lazagne/config/soft_import_module.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from importlib import import_module
+
+from lazagne.config.module_info import ModuleInfo
+
+
+def soft_import(package_name, module_name):
+    """ Imports module or return mock object which only print error
+    """
+    try:
+        module = import_module(package_name)
+        return getattr(module, module_name)
+    except ImportError as ex:
+
+        #  Emulate import ModuleInfo: return object (function) which generates objects of type ModuleInfo
+        #  This could be done with metaclasses, but now let's just keep it simple.
+        def get_import_error_mock(module_name, exception):
+            return lambda *args, **kwargs: _MOCK_ImportErrorInModule(module_name, exception)
+
+        return get_import_error_mock(module_name, ex)
+
+
+class _MOCK_ImportErrorInModule(ModuleInfo):
+
+    def __init__(self, name, exception):
+        super().__init__(name, "unused")
+        self.__message_to_print = "Module %s is not used due to unresolved dependence:\r\n%s" % (name, str(exception))
+
+    def run(self):
+        self.error(self.__message_to_print)

--- a/Linux/lazagne/softwares/browsers/chromium_based.py
+++ b/Linux/lazagne/softwares/browsers/chromium_based.py
@@ -141,18 +141,3 @@ class ChromiumBased(ModuleInfo):
                 all_passwords.append(pw)
 
         return all_passwords
-
-
-# Name, path
-chromium_browsers = [
-    (u'Google Chrome', u'.config/google-chrome'),
-    (u'Chromium', u'.config/chromium'),
-    (u'Brave', u'.config/BraveSoftware/Brave-Browser'),
-    (u'SlimJet', u'.config/slimjet'),
-    (u'Dissenter Browser', u'.config/GabAI/Dissenter-Browser'),
-    (u'Vivaldi', u'.config/vivaldi'),
-    # (u'SuperBird', u'.config/superbird'),  # FIXME
-    # (u'Whale', u'.config/naver-whale'),  # FIXME returns bytes
-]
-
-chromium_browsers = [ChromiumBased(browser_name=name, path=path) for name, path in chromium_browsers]

--- a/Linux/lazagne/softwares/browsers/chromium_based.py
+++ b/Linux/lazagne/softwares/browsers/chromium_based.py
@@ -11,11 +11,10 @@ from hashlib import pbkdf2_hmac
 # For non-keyring storage
 from Crypto.Cipher import AES
 
-from lazagne.config.constant import constant
+from lazagne.config.constant import constant, python_version
 from lazagne.config.crypto.pyaes import AESModeOfOperationCBC
 from lazagne.config.module_info import ModuleInfo
 from lazagne.config import homes
-from lazagne.softwares.browsers.mozilla import python_version
 
 
 class ChromiumBased(ModuleInfo):

--- a/Linux/lazagne/softwares/browsers/chromium_browsers.py
+++ b/Linux/lazagne/softwares/browsers/chromium_browsers.py
@@ -1,0 +1,18 @@
+from lazagne.config.soft_import_module import soft_import
+
+
+ChromiumBased = soft_import("lazagne.softwares.browsers.chromium_based", "ChromiumBased")
+
+# Name, path
+chromium_browsers_paths = [
+    (u'Google Chrome', u'.config/google-chrome'),
+    (u'Chromium', u'.config/chromium'),
+    (u'Brave', u'.config/BraveSoftware/Brave-Browser'),
+    (u'SlimJet', u'.config/slimjet'),
+    (u'Dissenter Browser', u'.config/GabAI/Dissenter-Browser'),
+    (u'Vivaldi', u'.config/vivaldi'),
+    # (u'SuperBird', u'.config/superbird'),  # FIXME
+    # (u'Whale', u'.config/naver-whale'),  # FIXME returns bytes
+]
+
+chromium_browsers = [ChromiumBased(browser_name=name, path=path) for name, path in chromium_browsers_paths]

--- a/Linux/lazagne/softwares/browsers/chromium_browsers.py
+++ b/Linux/lazagne/softwares/browsers/chromium_browsers.py
@@ -1,7 +1,7 @@
 from lazagne.config.soft_import_module import soft_import
 
-
-ChromiumBased = soft_import("lazagne.softwares.browsers.chromium_based", "ChromiumBased")
+chromium_based_module_location = "lazagne.softwares.browsers.chromium_based", "ChromiumBased"
+ChromiumBased = soft_import(*chromium_based_module_location)
 
 # Name, path
 chromium_browsers_paths = [

--- a/Linux/lazagne/softwares/browsers/firefox_browsers.py
+++ b/Linux/lazagne/softwares/browsers/firefox_browsers.py
@@ -1,7 +1,7 @@
 from lazagne.config.soft_import_module import soft_import
 
-
-Mozilla = soft_import("lazagne.softwares.browsers.mozilla", "Mozilla")
+mozilla_module_location = "lazagne.softwares.browsers.mozilla", "Mozilla"
+Mozilla = soft_import(*mozilla_module_location)
 
 # Name, path
 firefox_browsers = [

--- a/Linux/lazagne/softwares/browsers/firefox_browsers.py
+++ b/Linux/lazagne/softwares/browsers/firefox_browsers.py
@@ -1,0 +1,14 @@
+from lazagne.config.soft_import_module import soft_import
+
+
+Mozilla = soft_import("lazagne.softwares.browsers.mozilla", "Mozilla")
+
+# Name, path
+firefox_browsers = [
+    (u'firefox', u'.mozilla/firefox'),
+    (u'icecat', u'.mozilla/icecat'),
+    (u'waterfox', u'.waterfox'),
+    # (u'Pale Moon', u'.moonchild productions/pale moon'), FIXME
+]
+
+firefox_browsers = [Mozilla(browser_name=name, path=path) for name, path in firefox_browsers]

--- a/Linux/lazagne/softwares/browsers/mozilla.py
+++ b/Linux/lazagne/softwares/browsers/mozilla.py
@@ -7,7 +7,6 @@ import hmac
 import json
 import sqlite3
 import struct
-import sys
 import traceback
 import os
 
@@ -15,7 +14,7 @@ from lazagne.config.module_info import ModuleInfo
 from lazagne.config.crypto.pyDes import triple_des, CBC
 from lazagne.config.crypto.pyaes import AESModeOfOperationCBC
 from lazagne.config.dico import get_dic
-from lazagne.config.constant import constant
+from lazagne.config.constant import constant, python_version
 from pyasn1.codec.der import decoder
 from lazagne.config import homes
 from binascii import unhexlify
@@ -27,8 +26,6 @@ try:
 except ImportError:
     from configparser import RawConfigParser  # Python 3
 
-if sys.version_info[0]:
-    python_version = sys.version_info[0]
 
 def l(n):
     try:

--- a/Linux/lazagne/softwares/browsers/mozilla.py
+++ b/Linux/lazagne/softwares/browsers/mozilla.py
@@ -543,14 +543,3 @@ class Mozilla(ModuleInfo):
                 self.info(u'Database empty')
 
         return pwd_found
-
-
-# Name, path
-firefox_browsers = [
-    (u'firefox', u'.mozilla/firefox'),
-    (u'icecat', u'.mozilla/icecat'),
-    (u'waterfox', u'.waterfox'),
-    # (u'Pale Moon', u'.moonchild productions/pale moon'), FIXME
-]
-
-firefox_browsers = [Mozilla(browser_name=name, path=path) for name, path in firefox_browsers]

--- a/Linux/lazagne/softwares/memory/mimipy.py
+++ b/Linux/lazagne/softwares/memory/mimipy.py
@@ -20,7 +20,7 @@ import traceback
 
 from lazagne.config.lib.memorpy import *
 from lazagne.config.module_info import ModuleInfo
-from lazagne.softwares.browsers.mozilla import python_version
+from lazagne.config.constant import python_version
 
 
 class Mimipy(ModuleInfo):


### PR DESCRIPTION
As mentioned in #558, I think it is good idea to try to run LaZagne with modules available on current system.  
This PR does not resolve this issue, but just demonstrates proof of concept that it could be done **without editing modules itself**. For completely resolve it same thing should be done for Windows and MacOS. This PR is only affects Linux.  

I used **dynamically import for all modules**. Failed to import modules are appeared in category `unused`. If they a called (with option `all`) they call method `error` and pass meassage with exception as parameter.  
I also provide hook for **PyInstaller**. It need to set parameter `--additional-hooks-dir` for PyInstaller. Example:  
`pyinstaller --additional-hooks-dir=. --onefile ./laZagne.py`

I have tested this code. If @AlessandroZ think this is good enough, I could do the same for Windows. I also could do the same for MacOS, but I could not test this.