### PR TITLE
Do not use modules with broken depensences

### DIFF
--- a/Mac/laZagne.spec
+++ b/Mac/laZagne.spec
@@ -1,0 +1,42 @@
+# -*- mode: python ; coding: utf-8 -*-
+import sys
+sys.path.append(".")
+from lazagne.config.manage_modules import get_modules_names
+from lazagne.softwares.browsers.firefox_browsers import mozilla_based_module_location
+
+all_hidden_imports_module_names = get_modules_names()
+all_hidden_imports_module_names.append(mozilla_based_module_location)
+
+hiddenimports = [package_name for package_name, module_name in all_hidden_imports_module_names]
+
+block_cipher = None
+
+
+a = Analysis(['laZagne.py'],
+             pathex=[''],
+             binaries=[],
+             datas=[],
+             hiddenimports=hiddenimports,
+             hookspath=['.'],
+             runtime_hooks=[],
+             excludes=[],
+             win_no_prefer_redirects=False,
+             win_private_assemblies=False,
+             cipher=block_cipher,
+             noarchive=False)
+pyz = PYZ(a.pure, a.zipped_data,
+             cipher=block_cipher)
+exe = EXE(pyz,
+          a.scripts,
+          a.binaries,
+          a.zipfiles,
+          a.datas,
+          [],
+          name='laZagne',
+          debug=False,
+          bootloader_ignore_signals=False,
+          strip=False,
+          upx=True,
+          upx_exclude=[],
+          runtime_tmpdir=None,
+          console=True )

--- a/Mac/lazagne/config/manage_modules.py
+++ b/Mac/lazagne/config/manage_modules.py
@@ -14,15 +14,19 @@ def get_categories():
     return category
 
 
-def get_modules():
-    module_names = [
+def get_modules_names():
+    return [
         # system
-        soft_import("lazagne.softwares.system.hashdump", "HashDump")(),
-        soft_import("lazagne.softwares.system.chainbreaker", "ChainBreaker")(),
-        soft_import("lazagne.softwares.system.system", "System")(),
+        ("lazagne.softwares.system.hashdump", "HashDump"),
+        ("lazagne.softwares.system.chainbreaker", "ChainBreaker"),
+        ("lazagne.softwares.system.system", "System"),
         # mails
-        soft_import("lazagne.softwares.mails.thunderbird", "Thunderbird")(),
+        ("lazagne.softwares.mails.thunderbird", "Thunderbird"),
         # browsers
-        soft_import("lazagne.softwares.browsers.chrome", "Chrome")(),
+        ("lazagne.softwares.browsers.chrome", "Chrome")
     ]
-    return module_names + firefox_browsers
+
+
+def get_modules():
+    modules = [soft_import(package_name, module_name)() for package_name, module_name in get_modules_names()]
+    return modules + firefox_browsers

--- a/Mac/lazagne/config/manage_modules.py
+++ b/Mac/lazagne/config/manage_modules.py
@@ -1,17 +1,7 @@
 # -*- coding: utf-8 -*- 
 # !/usr/bin/python
-
-# browsers
-from lazagne.softwares.browsers.mozilla import firefox_browsers
-from lazagne.softwares.browsers.chrome import Chrome
-
-# mails 
-from lazagne.softwares.mails.thunderbird import Thunderbird
-
-# system
-from lazagne.softwares.system.hashdump import HashDump
-from lazagne.softwares.system.chainbreaker import ChainBreaker
-from lazagne.softwares.system.system import System
+from lazagne.config.soft_import_module import soft_import
+from lazagne.softwares.browsers.firefox_browsers import firefox_browsers
 
 
 def get_categories():
@@ -19,16 +9,20 @@ def get_categories():
         'browsers': {'help': 'Web browsers supported'},
         'mails': {'help': 'Email clients supported'},
         'system': {'help': 'System credentials'},
+        'unused': {'help': 'This modules could not be used because of broken dependence'}
     }
     return category
 
 
 def get_modules():
     module_names = [
-        Thunderbird(),
-        Chrome(),
-        HashDump(),
-        ChainBreaker(),
-        System()
+        # system
+        soft_import("lazagne.softwares.system.hashdump", "HashDump")(),
+        soft_import("lazagne.softwares.system.chainbreaker", "ChainBreaker")(),
+        soft_import("lazagne.softwares.system.system", "System")(),
+        # mails
+        soft_import("lazagne.softwares.mails.thunderbird", "Thunderbird")(),
+        # browsers
+        soft_import("lazagne.softwares.browsers.chrome", "Chrome")(),
     ]
     return module_names + firefox_browsers

--- a/Mac/lazagne/config/soft_import_module.py
+++ b/Mac/lazagne/config/soft_import_module.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from importlib import import_module
+
+from lazagne.config.module_info import ModuleInfo
+
+
+def soft_import(package_name, module_name):
+    """ Imports module or return mock object which only print error
+    """
+    try:
+        module = import_module(package_name)
+        return getattr(module, module_name)
+    except ImportError as ex:
+
+        #  Emulate import ModuleInfo: return object (function) which generates objects of type ModuleInfo
+        #  This could be done with metaclasses, but now let's just keep it simple.
+        def get_import_error_mock(module_name, exception):
+            return lambda *args, **kwargs: _MOCK_ImportErrorInModule(module_name, exception)
+
+        return get_import_error_mock(module_name, ex)
+
+
+class _MOCK_ImportErrorInModule(ModuleInfo):
+
+    def __init__(self, name, exception):
+        super(_MOCK_ImportErrorInModule, self).__init__(name, "unused")
+        self.__message_to_print = "Module %s is not used due to unresolved dependence:\r\n%s" % (name, str(exception))
+
+    def run(self):
+        self.error(self.__message_to_print)

--- a/Mac/lazagne/softwares/browsers/firefox_browsers.py
+++ b/Mac/lazagne/softwares/browsers/firefox_browsers.py
@@ -1,7 +1,8 @@
 from lazagne.config.soft_import_module import soft_import
 
 
-Mozilla = soft_import("lazagne.softwares.browsers.mozilla", "Mozilla")
+mozilla_based_module_location = "lazagne.softwares.browsers.mozilla", "Mozilla"
+Mozilla = soft_import(*mozilla_based_module_location)
 
 # Name, path
 firefox_browsers = [

--- a/Mac/lazagne/softwares/browsers/firefox_browsers.py
+++ b/Mac/lazagne/softwares/browsers/firefox_browsers.py
@@ -1,0 +1,17 @@
+from lazagne.config.soft_import_module import soft_import
+
+
+Mozilla = soft_import("lazagne.softwares.browsers.mozilla", "Mozilla")
+
+# Name, path
+firefox_browsers = [
+    (u'firefox', u"~/Library/Application Support/Firefox/"),
+    # Check these paths on Mac systems
+    # (u'BlackHawk', u'{APPDATA}\\NETGATE Technologies\\BlackHawk'),
+    # (u'Cyberfox', u'{APPDATA}\\8pecxstudios\\Cyberfox'),
+    # (u'Comodo IceDragon', u'{APPDATA}\\Comodo\\IceDragon'),
+    # (u'K-Meleon', u'{APPDATA}\\K-Meleon'),
+    # (u'Icecat', u'{APPDATA}\\Mozilla\\icecat'),
+]
+
+firefox_browsers = [Mozilla(browser_name=name, path=path) for name, path in firefox_browsers]

--- a/Mac/lazagne/softwares/browsers/mozilla.py
+++ b/Mac/lazagne/softwares/browsers/mozilla.py
@@ -539,17 +539,3 @@ class Mozilla(ModuleInfo):
                     self.info(u'Database empty')
 
             return pwd_found
-
-
-# Name, path
-firefox_browsers = [
-    (u'firefox', u"~/Library/Application Support/Firefox/"),
-    # Check these paths on Mac systems
-    # (u'BlackHawk', u'{APPDATA}\\NETGATE Technologies\\BlackHawk'),
-    # (u'Cyberfox', u'{APPDATA}\\8pecxstudios\\Cyberfox'),
-    # (u'Comodo IceDragon', u'{APPDATA}\\Comodo\\IceDragon'),
-    # (u'K-Meleon', u'{APPDATA}\\K-Meleon'),
-    # (u'Icecat', u'{APPDATA}\\Mozilla\\icecat'),
-]
-
-firefox_browsers = [Mozilla(browser_name=name, path=path) for name, path in firefox_browsers]


### PR DESCRIPTION
Do not use modules with broken depensences for Mac OS and create `lazagne.spec` file to compile new code in pyinstaller.  

**WARNING!!** I have no Mac, so **I haven't tested it**, but it all same as #564.  
I have only done PR as in [comment](https://github.com/AlessandroZ/LaZagne/pull/564#issuecomment-859462184).