### PR TITLE
Fixed bug in adding CREDHIST file.

### DIFF
--- a/Windows/lazagne/config/DPAPI/masterkey.py
+++ b/Windows/lazagne/config/DPAPI/masterkey.py
@@ -287,7 +287,7 @@ class MasterKeyPool(object):
         """
         if os.path.exists(credfile):
             try:
-                with open(credfile) as f:
+                with open(credfile, 'rb') as f:
                     self.credhists[sid] = CredHistFile(f.read())
             except Exception:
                 pass


### PR DESCRIPTION
Previously code has just silently failed because of lines 292-293. It expected `self.raw` to be a binary data in `Eater.read()` method, but python3 decoded it to a string by default.