### PR TITLE
Fix multiple issue

### DIFF
--- a/Windows/lazagne/config/DPAPI/credhist.py
+++ b/Windows/lazagne/config/DPAPI/credhist.py
@@ -139,4 +139,7 @@ class CredHistFile(DataStruct):
         Decrypts this credhist entry with the given user's password.
         Simply computes the password hash then calls self.decrypt_with_hash()
         """
+        if isinstance(password, bytes):
+            password = password.decode("latin-1")
+
         self.decrypt_with_hash(hashlib.sha1(password.encode("UTF-16LE")).digest())

--- a/Windows/lazagne/config/DPAPI/masterkey.py
+++ b/Windows/lazagne/config/DPAPI/masterkey.py
@@ -446,15 +446,19 @@ class MasterKeyPool(object):
             for mkf in self.keys[guid].get('mkf', ''):
                 if not mkf.decrypted:
                     mk = mkf.masterkey
-                    mk.decrypt_with_key(self.system.user)
-                    if not mk.decrypted:
-                        mk.decrypt_with_key(self.system.machine)
+                    if mk:
+                        mk.decrypt_with_key(self.system.user)
+                        if not mk.decrypted:
+                            mk.decrypt_with_key(self.system.machine)
 
-                    if mk.decrypted:
-                        mkf.decrypted = True
-                        self.nb_mkf_decrypted += 1
+                        if mk.decrypted:
+                            mkf.decrypted = True
+                            self.nb_mkf_decrypted += 1
 
-                        yield True, u'System masterkey decrypted for {masterkey}'.format(masterkey=mkf.guid.decode())
+                            yield True, u'System masterkey decrypted for {masterkey}'.format(masterkey=mkf.guid.decode())
+                        else:
+                            yield False, u'System masterkey not decrypted for masterkey {masterkey}'.format(
+                                masterkey=mkf.guid.decode())
                     else:
-                        yield False, u'System masterkey not decrypted for masterkey {masterkey}'.format(
-                            masterkey=mkf.guid.decode())
+                        yield False, u'System masterkey not found for masterkey {masterkey}'.format(
+                            masterkey=mkf)


### PR DESCRIPTION
Issues fixed:

- [x] `AttributeError: 'bytes' object has no attribute 'encode'` in _Windows/lazagne/config/DPAPI/**credhist.py**_
- [x] `AttributeError: 'NoneType' object has no attribute 'decrypt_with_key'` in _Windows/lazagne/config/DPAPI/**masterkey.py**_