### PR TITLE
Fix error "'Mozilla' object has no attribute 'getLoginData'"

### DIFF
--- a/Mac/lazagne/softwares/browsers/mozilla.py
+++ b/Mac/lazagne/softwares/browsers/mozilla.py
@@ -523,7 +523,7 @@ class Mozilla(ModuleInfo):
             for profile in self.get_firefox_profiles(self.path):
                 self.info(u'Profile path found: {profile}'.format(profile=profile))
 
-                credentials = self.getLoginData(profile)
+                credentials = self.get_login_data(profile)
                 if credentials:
                     for key in self.get_key(profile):
                         for user, password, url in credentials:


### PR DESCRIPTION
This should fix #658. I have no MAC, so I not able to check it. But I absolutely sure It shoulf fix it. May be it will fail again with some another error =)