### PR TITLE
Fix windows release builds

### DIFF
--- a/.github/workflows/WinCompile.yml
+++ b/.github/workflows/WinCompile.yml
@@ -2,23 +2,31 @@ name: Build and Upload LaZagne Release
 
 on:
   push:
-    # Sequence of patterns matched against refs/tags
     tags:
-    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+      - 'v*' # Matches tags like v1.0, v20.15.10
 
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v2
 
-    - name: Build Application
-      uses: JackMcKew/pyinstaller-action-windows@main
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v4
       with:
-        path: Windows
-        requirements: requirements.txt
+        python-version: 3.11
+
+    - name: Install Dependencies
+      run: |
+        cd Windows
+        pip install -r requirements.txt
+
+    - name: Build Executable with PyInstaller
+      run: |
+        cd Windows
+        pyinstaller lazagne.spec
 
     - name: Create Release
       id: create_release

--- a/.github/workflows/WinCompile.yml
+++ b/.github/workflows/WinCompile.yml
@@ -46,6 +46,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: Windows/dist/windows/lazagne.exe
+        asset_path: Windows/dist/lazagne.exe
         asset_name: LaZagne.exe
         asset_content_type: application/octet-stream

--- a/Windows/requirements.txt
+++ b/Windows/requirements.txt
@@ -1,0 +1,9 @@
+psutil; sys_platform == 'linux' or sys_platform == 'linux2'
+secretstorage; sys_platform == 'linux' or sys_platform == 'linux2'
+pyasn1
+enum34; python_version < '3.4' and sys_platform == 'win32'
+rsa; sys_platform == 'win32'
+#https://github.com/AlessandroZ/pypykatz/archive/master.zip; python_version < '3.4' and sys_platform == 'win32'
+#https://github.com/skelsec/pypykatz/archive/master.zip; python_version  > '3.5' and sys_platform == 'win32'
+pycryptodome
+pyinstaller


### PR DESCRIPTION
use `windows-latest` directly with  `Python 3.11`to build windows binary instead of `JackMcKew/pyinstaller-action-windows@main` on ubuntu latest 

fixes https://github.com/AlessandroZ/LaZagne/issues/669 and https://github.com/AlessandroZ/LaZagne/issues/667

